### PR TITLE
Display extra parameters in drop down

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -381,13 +381,13 @@ a.help-button{
 table.table.reports-table{
     table-layout: auto;
 }
-a:not([href]).object-pair-button{
+a:not([href]).collapser-button{
     color: #007bff;
 }
-a:not([href]).object-pair-button:hover{
+a:not([href]).collapser-button:hover{
     color: #0056b3;
 }
-.object-pair-button::after{
+.collapser-button::after{
     width: 0; 
     height: 0; 
     border-left: 5px solid transparent;
@@ -398,7 +398,7 @@ a:not([href]).object-pair-button:hover{
     margin-top: 7px;
     margin-left: 7px;
 }
-.object-pair-button.collapsed::after{
+.collapser-button.collapsed::after{
     transform: rotate(180deg);
 }
 .report-field-filters{
@@ -626,4 +626,9 @@ div.report-header{
     padding-bottom: .5rem;
     margin-bottom: 1rem;
     border-bottom: 1px solid #dee2e6;
+}
+.extra-params-wrapper pre{
+    background-color: #EEE;
+    border: 1px solid #AAA;
+    padding: .5em;
 }

--- a/sfa_dash/static/js/event-report-handling.js
+++ b/sfa_dash/static/js/event-report-handling.js
@@ -333,7 +333,7 @@ $(document).ready(function() {
     pair_index = 0;
     // call the function to initialize the pair creation widget and insert it into the DOM
     pair_selector = createPairSelector();
-    pair_control_container.append($('<a role="button" class="full-width object-pair-button collapsed" data-toggle="collapse" data-target=".pair-selector-wrapper">Create Forecast Evaluation pairs</a>'));
+    pair_control_container.append($('<a role="button" class="full-width collapser-button collapsed" data-toggle="collapse" data-target=".pair-selector-wrapper">Create Forecast Evaluation pairs</a>'));
     pair_control_container.append(pair_selector);
     registerDatetimeValidator('period-start');
     registerDatetimeValidator('period-end')

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -762,7 +762,7 @@ $(document).ready(function() {
     pair_index = 0;
     // call the function to initialize the pair creation widget and insert it into the DOM
     pair_selector = createPairSelector();
-    pair_control_container.append($('<a role="button" class="full-width object-pair-button collapsed" data-toggle="collapse" data-target=".pair-selector-wrapper">Create Forecast Evaluation pairs</a>'));
+    pair_control_container.append($('<a role="button" class="full-width object-pair-button collapser-button collapsed" data-toggle="collapse" data-target=".pair-selector-wrapper">Create Forecast Evaluation pairs</a>'));
     pair_control_container.append(pair_selector);
     registerDatetimeValidator('period-start');
     registerDatetimeValidator('period-end')

--- a/sfa_dash/templates/data/metadata/aggregate_metadata.html
+++ b/sfa_dash/templates/data/metadata/aggregate_metadata.html
@@ -14,4 +14,5 @@
   {{ macro.li('Value type', interval_value_type ) }}
   {{ macro.li('Aggregate type', aggregate_type ) }}
 </ul>
+{% include "data/metadata/extra_parameters.html" %}
 {% endblock %}

--- a/sfa_dash/templates/data/metadata/data_metadata.html
+++ b/sfa_dash/templates/data/metadata/data_metadata.html
@@ -25,4 +25,5 @@
   {% block extra_fields %}
   {% endblock %}
 </ul>
+{% include "data/metadata/extra_parameters.html" %}
 {% endblock %}

--- a/sfa_dash/templates/data/metadata/extra_parameters.html
+++ b/sfa_dash/templates/data/metadata/extra_parameters.html
@@ -2,7 +2,11 @@
 <div class="data-metadata-extra-parameters-field container">
   <a role="button" class="collapser-button collapsed" data-toggle="collapse" data-target=".extra-params-wrapper">Extra parameters</a>
   <div class="extra-params-wrapper collapse">
+    {# Due to the loose format of extra parameters, ensure that autoescaping is
+       enabled in this block #}
+    {% autoescape true %}
     <pre>{{ extra_parameters }}</pre>
+    {% endautoescape %}
   </div>
 </div>
 {% endif %}

--- a/sfa_dash/templates/data/metadata/extra_parameters.html
+++ b/sfa_dash/templates/data/metadata/extra_parameters.html
@@ -1,0 +1,8 @@
+{% if extra_parameters | length %}
+<div class="data-metadata-extra-parameters-field container">
+  <a role="button" class="collapser-button collapsed" data-toggle="collapse" data-target=".extra-params-wrapper">Extra parameters</a>
+  <div class="extra-params-wrapper collapse">
+    <pre>{{ extra_parameters }}</pre>
+  </div>
+</div>
+{% endif %}

--- a/sfa_dash/templates/data/metadata/site_metadata.html
+++ b/sfa_dash/templates/data/metadata/site_metadata.html
@@ -33,4 +33,5 @@
     </li>
   {% endif %}
 </ul>
+{% include "data/metadata/extra_parameters.html" %}
 {% endblock %}


### PR DESCRIPTION
closes #204 
Adds an expandable extra parameters field to the box of metadata fields. This was suprisingly simple, and Jinja does a good job of escaping the contents of the field. To be sure we don't accidentally include the extra parameters in a block with autoescape turned off, I've wrapped the print statement in an explicit `{% autocomplete true %}` block, and put all of this html in a template to be included elsewhere.
Screenshots:
Collapsed
![Screenshot from 2020-05-19 11-21-51](https://user-images.githubusercontent.com/21206164/82363837-3ed46200-99c3-11ea-8fb6-4089fdf73557.png)
Expanded with json:
![Screenshot from 2020-05-19 11-22-15](https://user-images.githubusercontent.com/21206164/82363847-41cf5280-99c3-11ea-8b97-9bb064ecb819.png)
Expanded with newlines and malicious extra parameters:
![Screenshot from 2020-05-19 11-23-19](https://user-images.githubusercontent.com/21206164/82363991-83f89400-99c3-11ea-85ed-2d7bbf620d33.png)
