### PR TITLE
Add validation for name field and uploaded data

### DIFF
--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -1,0 +1,46 @@
+MAX_FILESIZE = 16777216;
+$(document).ready(function(){
+    // Custom validity handlers to supply users with more meaningful messages
+    // when they provide invalid input.
+    if(document.getElementsByName('name').length >0){
+        // Listen for invalid input
+        document.getElementsByName('name')[0].addEventListener(
+            'invalid', function(){
+                this.setCustomValidity(
+                    `Name may only contain characters a-z, A-Z, 0-9,
+                    '(', ')', '-', and '_'.`);
+            }
+        );
+        // clear any invalid state and check for validity to trigger an invalid
+        // event
+        document.getElementsByName('name')[0].addEventListener(
+            'input',function(){
+                console.log('oninput fire');
+                this.setCustomValidity('');
+                this.checkValidity();    
+            }
+        );
+    
+    }
+
+    // Validate file uploads are within the required range
+    $('input:file').change(function(){
+        if(this.files.length > 0){
+            if(this.files[0].size > MAX_FILESIZE){
+                $(this).after(
+                    $('<div>')
+                        .addClass(['alert', 'alert-danger'])
+                        .html(
+                            `The file selected is too large. The maximum file
+                             upload file size is
+                             ${MAX_FILESIZE / (1024 * 1024)}MB. Your file is
+                             ${(this.files[0].size / (1024 * 1024)).toFixed(4)}
+                             MB.`)
+                );
+                $('button:submit').prop('disabled', true);
+            } else {
+                $('button:submit').prop('disabled', false);
+            }
+        }
+    });
+});

--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -8,7 +8,7 @@ $(document).ready(function(){
             'invalid', function(){
                 this.setCustomValidity(
                     `Name may only contain characters a-z, A-Z, 0-9,
-                    '(', ')', '-', and '_'.`);
+                    (, ), -, and _.`);
             }
         );
         // clear any invalid state and check for validity to trigger an invalid

--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -1,4 +1,4 @@
-MAX_FILESIZE = 16777216;
+MAX_FILESIZE = 16 * 1024 * 1024;
 $(document).ready(function(){
     // Custom validity handlers to supply users with more meaningful messages
     // when they provide invalid input.
@@ -7,15 +7,13 @@ $(document).ready(function(){
         document.getElementsByName('name')[0].addEventListener(
             'invalid', function(){
                 this.setCustomValidity(
-                    `Name may only contain characters a-z, A-Z, 0-9,
-                    (, ), -, and _.`);
+                    `Name may only contain characters a-zA-Z0-9(), -'_.`);
             }
         );
         // clear any invalid state and check for validity to trigger an invalid
         // event
         document.getElementsByName('name')[0].addEventListener(
             'input',function(){
-                console.log('oninput fire');
                 this.setCustomValidity('');
                 this.checkValidity();
             }

--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -17,10 +17,9 @@ $(document).ready(function(){
             'input',function(){
                 console.log('oninput fire');
                 this.setCustomValidity('');
-                this.checkValidity();    
+                this.checkValidity();
             }
         );
-    
     }
 
     // Validate file uploads are within the required range

--- a/sfa_dash/templates/base.html
+++ b/sfa_dash/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="en" class="h-100">
   <head>
     {% include "head.html" %}
+    {% block extra_scripts %}{% endblock %}
   </head>
   <body class="d-flex flex-column h-100">
     <header class="fixed-top">

--- a/sfa_dash/templates/forms/base/aggregate_object_creation_form.html
+++ b/sfa_dash/templates/forms/base/aggregate_object_creation_form.html
@@ -1,5 +1,8 @@
 {% import "forms/form_macros.jinja" as form %}
 {% extends "dash/data.html" %}
+{% block extra_scripts %}
+<script src="/static/js/form-validation.js"></script>
+{% endblock %}
 {% block content %}
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}

--- a/sfa_dash/templates/forms/base/base_form.html
+++ b/sfa_dash/templates/forms/base/base_form.html
@@ -1,5 +1,9 @@
 {% import "forms/form_macros.jinja" as form %}
 {% extends "dash/data.html" %}
+{% block extra_scripts %}
+<script src="/static/js/form-validation.js"></script>
+{% endblock %}
+
 {% block content %}
 {% include "sections/notifications.html" %}
 <form action="" method="post" enctype="application/json" id="the-form-id">

--- a/sfa_dash/templates/forms/base/creation_form.html
+++ b/sfa_dash/templates/forms/base/creation_form.html
@@ -1,5 +1,8 @@
 {% import "forms/form_macros.jinja" as form %}
 {% extends "dash/data.html" %}
+{% block extra_scripts %}
+<script src="/static/js/form-validation.js"></script>
+{% endblock %}
 {% block content %}
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}

--- a/sfa_dash/templates/forms/base/download_form.html
+++ b/sfa_dash/templates/forms/base/download_form.html
@@ -1,5 +1,8 @@
 {% import "forms/form_macros.jinja" as form %}
 {% extends "dash/data.html" %}
+{% block extra_scripts %}
+<script src="/static/js/form-validation.js"></script>
+{% endblock %}
 {% block content %}
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}

--- a/sfa_dash/templates/forms/base/upload_form.html
+++ b/sfa_dash/templates/forms/base/upload_form.html
@@ -1,5 +1,8 @@
 {% import "forms/form_macros.jinja" as form %}
 {% extends "dash/data.html" %}
+{% block extra_scripts %}
+<script src="/static/js/form-validation.js"></script>
+{% endblock %}
 {% block content %}
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
@@ -10,6 +13,10 @@
     {% block fields %}
     {% endblock %}
     <div class="form-element full-width">
+
+        <p>Files should contain a maximum of 200,000 data points and have a
+           maximum size of 16MB. Uploaded data will truncated to 8 points of
+           decimal precision.</p>
         <input type="file" name="{{ data_type }}-data" accept=".csv, .json">
     </div>
     {{ form.token() }}

--- a/sfa_dash/templates/forms/form_macros.jinja
+++ b/sfa_dash/templates/forms/form_macros.jinja
@@ -1,3 +1,5 @@
+{% macro name_validation() %}pattern="[A-Za-z0-9(), \-_']+" maxlength=64{% endmacro %}
+
 {% macro help_button(name) %}
 <a data-toggle="collapse" data-target=".{{ name }}-help-text" role="button" href="" class="help-button">?</a>
 {% endmacro %}
@@ -14,7 +16,7 @@
 {% endif %}
 <label>{{ label }}</label><br/>
 <div class="input-wrapper">
-<input type="{{ type }}" class="form-control {{ class }} {{ name }}-field" {{ extra_attr }}  name="{{ name }}" {% if form_data is not none %}value="{{ form_data.get(name, default) }}"{% endif %}>{% if units is not none %}{{ units }}{% endif %}
+<input type="{{ type }}" class="form-control {{ class }} {{ name }}-field" {{ extra_attr }}  name="{{ name }}"  {% if name == 'name' %}{{ name_validation() }}{% endif %} {% if form_data is not none %}value="{{ form_data.get(name, default) }}"{% endif %}>{% if units is not none %}{{ units }}{% endif %}
 </div>
 {% if help_text is not none %}
 {{ help_button(name) }}

--- a/sfa_dash/templates/head.html
+++ b/sfa_dash/templates/head.html
@@ -18,6 +18,7 @@
 
 <!-- Custom styles for this template -->
 <link href="/static/css/styles.css" type="text/css" rel="stylesheet">
+
 {% if includes_bokeh %}
 {% set bkversion = bokeh_version | default('1.4.0') %}
 <link
@@ -36,7 +37,6 @@
 
 <script src="/static/js/table-search.js"></script>
 <script src="/static/js/table-checkall.js"></script>
-
 <script src="https://cdn.plot.ly/plotly-1.52.3.min.js"></script>
 
 {# inject the page_data json variable if provided by jinja #}


### PR DESCRIPTION
closes #254 Adds a validator for name fields that supplies a meaningful message on user input so users don't have to guess about allowed characters.
![Screenshot from 2020-05-22 13-59-37](https://user-images.githubusercontent.com/21206164/82709020-87468680-9c34-11ea-8479-265514754508.png)



This also checks file sizes in the file upload form and limits them to 16MB displaying an error when the size was exceeded. 
The timeout issues are most influenced by the formatting and storage of data on the API. Regardless of original format, files containing ~200k data points were about the limit of stability (on dev), so I arrived at 16MB based on the average size of some randomly generated bad-case JSON files (where date format has resolution finer than a minute, float precision of 10 decimal places) of 200k points. CSV files were ~ half the size of the json files and upload quickly but the subsequent validation process involving a get, processing and post is where the timeout occurs for larger uploads.

 I've added a note near the file selector warning the users of this limitation and the rounding of data when stored. A warning will appear if the user selects a file that is too large.

![Screenshot from 2020-05-22 13-56-44](https://user-images.githubusercontent.com/21206164/82708885-39ca1980-9c34-11ea-8869-5349e68e2068.png)
