### PR TITLE
Display and use available timerange

### DIFF
--- a/sfa_dash/api_interface/cdf_forecasts.py
+++ b/sfa_dash/api_interface/cdf_forecasts.py
@@ -14,3 +14,8 @@ def get_values(forecast_id, **kwargs):
 def post_values(uuid, values, json=True):
     req = post_request(f'/forecasts/cdf/single/{uuid}/values', values, json)
     return req
+
+
+def valid_times(forecast_id):
+    req = get_request(f'/forecasts/cdf/single/{forecast_id}/values/timerange')
+    return req

--- a/sfa_dash/api_interface/forecasts.py
+++ b/sfa_dash/api_interface/forecasts.py
@@ -34,3 +34,8 @@ def post_values(uuid, values, json=True):
 def delete(forecast_id):
     req = delete_request(f'/forecasts/single/{forecast_id}')
     return req
+
+
+def valid_times(forecast_id):
+    req = get_request(f'/forecasts/single/{forecast_id}/values/timerange')
+    return req

--- a/sfa_dash/api_interface/observations.py
+++ b/sfa_dash/api_interface/observations.py
@@ -32,3 +32,8 @@ def post_values(uuid, values, json=True):
 def delete(observation_id):
     req = delete_request(f'/observations/{observation_id}')
     return req
+
+
+def valid_times(observation_id):
+    req = get_request(f'/observations/{observation_id}/values/timerange')
+    return req

--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -313,12 +313,12 @@ class AggregateView(BaseView):
 
     def get(self, uuid, **kwargs):
         self.temp_args = {}
-        start, end = self.parse_start_end_from_querystring()
         try:
             self.metadata = self.api_handle.get_metadata(uuid)
         except DataRequestException as e:
             self.temp_args.update({'errors': e.errors})
         else:
+            start, end = self.parse_start_end_from_querystring()
             self.observation_list = []
             observations_list = observations.list_metadata()
             observation_dict = {obs['observation_id']: obs

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -48,6 +48,19 @@ class BaseView(MethodView):
                     'bokeh_script': script_plot[0]
                 })
 
+    def set_timerange(self):
+        """Retrieve the available timerange for an object and set the
+        'min_timestamp' and 'max_timestamp' keys in metdata. If the range
+        cannot be found the keys will not be set.
+        """
+        try:
+            timerange = self.api_handle.valid_times(self.metadata[self.id_key])
+        except DataRequestException:
+            return
+        else:
+            self.metadata['timerange_start'] = timerange['min_timestamp']
+            self.metadata['timerange_end'] = timerange['max_timestamp']
+
     def parse_start_end_from_querystring(self):
         """Attempts to find the start and end query parameters. If not found,
         returns defaults spanning the last three days. Used for setting

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -62,13 +62,17 @@ class BaseView(MethodView):
         start_arg = request.args.get('start', 'x')
         end_arg = request.args.get('end', 'x')
         try:
-            start = pd.Timestamp(start_arg)
-        except ValueError:
-            start = pd.Timestamp.utcnow() - pd.Timedelta('3days')
-        try:
             end = pd.Timestamp(end_arg)
         except ValueError:
-            end = pd.Timestamp.utcnow()
+            meta_end = self.metadata.get('timerange_end')
+            if meta_end is None:
+                end = pd.Timestamp.utcnow()
+            else:
+                end = pd.Timestamp(meta_end)
+        try:
+            start = pd.Timestamp(start_arg)
+        except ValueError:
+            start = end - pd.Timedelta('3days')
         return start, end
 
     def format_download_params(self, form_data):

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -98,19 +98,6 @@ class SingleObjectView(DataDashView):
                 uuid=self.metadata[self.id_key])
         return breadcrumb_dict
 
-    def set_timerange(self):
-        """Retrieve the available timerange for an object and set the
-        'min_timestamp' and 'max_timestamp' keys in metdata. If the range
-        cannot be found the keys will not be set.
-        """
-        try:
-            timerange = self.api_handle.valid_times(self.metadata[self.id_key])
-        except DataRequestException:
-            return
-        else:
-            self.metadata['timerange_start'] = timerange['min_timestamp']
-            self.metadata['timerange_end'] = timerange['max_timestamp']
-
     def set_template_args(self, start, end, **kwargs):
         """Insert necessary template arguments. See data/asset.html in the
         template folder for how these are layed out.

--- a/sfa_dash/templates/data/metadata/data_metadata.html
+++ b/sfa_dash/templates/data/metadata/data_metadata.html
@@ -24,6 +24,12 @@
   {{ macro.li('Interval length', interval_length | display_timedelta) }}
   {% block extra_fields %}
   {% endblock %}
+  {% if timerange_start is defined %}
+  {{ macro.li('Start', timerange_start | format_datetime) }}
+  {% endif %}
+  {% if timerange_end is defined %} 
+  {{ macro.li('End', timerange_end | format_datetime) }}
+  {% endif %}
 </ul>
 {% include "data/metadata/extra_parameters.html" %}
 {% endblock %}


### PR DESCRIPTION
closes #256 
Displays the start and end of the available timerange for all of the objects that are directly associated with a timeseries. Observations, forecasts, and probabilistic forecast constant values. Also using the returned `max_timestamp` to display the most recent three days of data.
Screenshot of the page on load:
![Screenshot from 2020-05-22 15-08-43](https://user-images.githubusercontent.com/21206164/82713447-dba33380-9c3f-11ea-8d02-ea2823bbaeda.png)

