### PR TITLE
check for none before passing timerange values to formatter

### DIFF
--- a/sfa_dash/templates/data/metadata/data_metadata.html
+++ b/sfa_dash/templates/data/metadata/data_metadata.html
@@ -24,11 +24,11 @@
   {{ macro.li('Interval length', interval_length | display_timedelta) }}
   {% block extra_fields %}
   {% endblock %}
-  {% if timerange_start is defined %}
-  {{ macro.li('Start', timerange_start | format_datetime) }}
+  {% if timerange_start is defined and timerange_start is not none %}
+    {{ macro.li('Start', timerange_start | format_datetime) }}
   {% endif %}
-  {% if timerange_end is defined %} 
-  {{ macro.li('End', timerange_end | format_datetime) }}
+  {% if timerange_end is defined and timerange_end is not none %} 
+    {{ macro.li('End', timerange_end | format_datetime) }}
   {% endif %}
 </ul>
 {% include "data/metadata/extra_parameters.html" %}


### PR DESCRIPTION
Fixes missed case where a new observation or forecast returns nulls in `/timerange` request.