### PR TITLE
Redirect to the report view on successful recompute

### DIFF
--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 
-from flask import url_for, render_template, request, session
+from flask import url_for, render_template, request, flash
 from flask.views import MethodView
 import pandas as pd
 
@@ -185,18 +185,18 @@ class BaseView(MethodView):
         """
         return OrderedDict()
 
-    def pop_notifications(self):
-        """Returns a dictionary of any messages, warnings or errors found in
-        the session.
+    def flash_api_errors(self, errors):
+        """Formats a dictionary of api errors and flashes them to the user on
+        the next request.
+
+        Parameters
+        ----------
+        errors: dict
+            Dict of errors returned by the API.
         """
-        messages = session.pop('messages', {})
-        warnings = session.pop('warnings', {})
-        errors = session.pop('errors', {})
-        return {
-            'messages': messages,
-            'warnings': warnings,
-            'errors': errors,
-        }
+        to_flash = [f'({key}) msg.join(", ")' for key, msg in errors]
+        for error in to_flash:
+            flash(error, 'error')
 
     def template_args(self):
         return {}

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -194,7 +194,7 @@ class BaseView(MethodView):
         errors: dict
             Dict of errors returned by the API.
         """
-        to_flash = [f'({key}) msg.join(", ")' for key, msg in errors]
+        to_flash = [f'({key}) {", ".join(msg)}' for key, msg in errors.items()]
         for error in to_flash:
             flash(error, 'error')
 

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 
-from flask import url_for, render_template, request
+from flask import url_for, render_template, request, session
 from flask.views import MethodView
 import pandas as pd
 
@@ -184,6 +184,19 @@ class BaseView(MethodView):
         Where the order of the keys is rendered from left to right.
         """
         return OrderedDict()
+
+    def pop_notifications(self):
+        """Returns a dictionary of any messages, warnings or errors found in
+        the session.
+        """
+        messages = session.pop('messages', {})
+        warnings = session.pop('warnings', {})
+        errors = session.pop('errors', {})
+        return {
+            'messages': messages,
+            'warnings': warnings,
+            'errors': errors,
+        }
 
     def template_args(self):
         return {}

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -1,5 +1,5 @@
 from flask import (request, redirect, url_for, render_template, send_file,
-                   current_app, session)
+                   current_app, flash)
 
 from solarforecastarbiter.datamodel import Report, RawReport
 from solarforecastarbiter.io.utils import load_report_values
@@ -221,12 +221,11 @@ class ReportView(BaseView):
         self.metadata = metadata
 
     def get(self, uuid):
-        notifications = self.pop_notifications()
         try:
             self.set_metadata(uuid)
         except DataRequestException as e:
             return render_template(self.template, uuid=uuid, errors=e.errors)
-        return super().get(**notifications)
+        return super().get()
 
 
 class DownloadReportView(ReportView):
@@ -320,10 +319,8 @@ class RecomputeReportView(BaseView):
         try:
             reports.recompute(uuid)
         except DataRequestException as e:
-            session['errors'] = e.errors
+            self.flash_api_errors(e.errors)
         else:
-            session['messages'] = {
-                'report': ['Report recomputed successfully']
-            }
+            flash('Report recomputed successfully.', 'message')
         return redirect(url_for('data_dashboard.report_view',
                                 uuid=uuid))

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -320,6 +320,5 @@ class RecomputeReportView(BaseView):
             reports.recompute(uuid)
         except DataRequestException as e:
             return ReportView().get(uuid, errors=e.errors)
-        return ReportView().get(
-            uuid,
-            messages={'report': ['recomputed successfully']})
+        return redirect(url_for('data_dashboard.report_view',
+                                uuid=uuid))

--- a/sfa_dash/blueprints/tests/test_base.py
+++ b/sfa_dash/blueprints/tests/test_base.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+from sfa_dash.blueprints.base import BaseView
+
+
+@pytest.mark.parametrize('errors,expected', [
+    ({'it': ['broke']}, '(it) broke'),
+    ({'2': ['er', 'rors']}, '(2) er, rors'),
+])
+def test_flash_errors_formatting(mocker, app, errors, expected):
+    flasher = mocker.patch('sfa_dash.blueprints.base.flash')
+    with app.test_request_context():
+        BaseView().flash_api_errors(errors)
+    flasher.assert_called_with(expected, 'error')

--- a/sfa_dash/blueprints/tests/test_base.py
+++ b/sfa_dash/blueprints/tests/test_base.py
@@ -13,3 +13,14 @@ def test_flash_errors_formatting(mocker, app, errors, expected):
     with app.test_request_context():
         BaseView().flash_api_errors(errors)
     flasher.assert_called_with(expected, 'error')
+
+
+@pytest.mark.parametrize('errors,expected', [
+    ({'it': ['broke'], '2': ['er', 'rors']}, ('(it) broke', '(2) er, rors')),
+])
+def test_flash_errors_list_comp(mocker, app, errors, expected):
+    flasher = mocker.patch('sfa_dash.blueprints.base.flash')
+    with app.test_request_context():
+        BaseView().flash_api_errors(errors)
+    calls = [mocker.call(exp, 'error') for exp in expected]
+    flasher.assert_has_calls(calls)

--- a/sfa_dash/templates/sections/notifications.html
+++ b/sfa_dash/templates/sections/notifications.html
@@ -1,3 +1,8 @@
+{% set flashed_messages = get_flashed_messages(category_filter=['message']) %}
+{% set flashed_warnings= get_flashed_messages(category_filter=['warning']) %}
+{% set flashed_errors = get_flashed_messages(category_filter=['error']) %}
+
+{% if messages is defined or (flashed_messages | length) > 0 %}
 <div class="messages">
   <ul class="message-list notification-list">
     {% if messages is defined %}
@@ -5,11 +10,14 @@
       <li class="alert alert-success"><p><b>{{ title }}: </b>{{ message | join(', ') | safe}}</p></li> 
 	{% endfor %}
     {% endif %}
-    {% for message in get_flashed_messages(category_filter=['message']) %}
+    {% for message in flashed_messages %}
     <li class="alert alert-success">{{ message }}</li>
     {% endfor %}
   </ul>
 </div>
+{% endif %}
+
+{% if warnings is defined or (flashed_warnings | length) > 0 %}
 <div class="warnings">
   <ul class="warning-list notification-list">
     {% if warnings is defined %}
@@ -17,12 +25,14 @@
     <li class="alert alert-warning"><p><b>{{ title }}: </b>{{ warning | join(', ') | safe}}</p></li>
     {% endfor %}
     {% endif %}
-    {% for warning in get_flashed_messages(category_filter=['warning']) %}
+    {% for warning in flashed_warnings %}
     <li class="alert alert-warning">{{ warning }}</li>
     {% endfor %}
   </ul>
 </div>
+{% endif %}
 
+{% if errors is defined or (flashed_errors | length) > 0 %}
 <div class="errors">
   <ul class="error-list notification-list">
     {% if errors is defined %}
@@ -30,9 +40,9 @@
     <li class="alert alert-danger"><p><b>{{ title }}: </b>{{ error | join(', ') | safe}}</p></li>
     {% endfor %}
     {% endif %}
-    {% for error in get_flashed_messages(category_filter=['error']) %}
+    {% for error in flashed_errors %}
     <li class="alert alert-danger">{{ error }}</li>
     {% endfor %}
   </ul>
 </div>
-
+{% endif %}

--- a/sfa_dash/templates/sections/notifications.html
+++ b/sfa_dash/templates/sections/notifications.html
@@ -1,29 +1,38 @@
-{% if messages is defined %}
 <div class="messages">
   <ul class="message-list notification-list">
+    {% if messages is defined %}
     {% for title, message in messages.items() %}
       <li class="alert alert-success"><p><b>{{ title }}: </b>{{ message | join(', ') | safe}}</p></li> 
 	{% endfor %}
+    {% endif %}
+    {% for message in get_flashed_messages(category_filter=['message']) %}
+    <li class="alert alert-success">{{ message }}</li>
+    {% endfor %}
   </ul>
 </div>
-{% endif %}
-{% if warnings is defined %}
 <div class="warnings">
   <ul class="warning-list notification-list">
-      {% for title, warning in warnings.items() %}
-      <li class="alert alert-warning"><p><b>{{ title }}: </b>{{ warning | join(', ') | safe}}</p></li>
-      {% endfor %}
+    {% if warnings is defined %}
+    {% for title, warning in warnings.items() %}
+    <li class="alert alert-warning"><p><b>{{ title }}: </b>{{ warning | join(', ') | safe}}</p></li>
+    {% endfor %}
+    {% endif %}
+    {% for warning in get_flashed_messages(category_filter=['warning']) %}
+    <li class="alert alert-warning">{{ warning }}</li>
+    {% endfor %}
   </ul>
 </div>
 
-{% endif %}
-{% if errors is defined %}
 <div class="errors">
   <ul class="error-list notification-list">
-      {% for title, error in errors.items() %}
-      <li class="alert alert-danger"><p><b>{{ title }}: </b>{{ error | join(', ') | safe}}</p></li>
-      {% endfor %}
+    {% if errors is defined %}
+    {% for title, error in errors.items() %}
+    <li class="alert alert-danger"><p><b>{{ title }}: </b>{{ error | join(', ') | safe}}</p></li>
+    {% endfor %}
+    {% endif %}
+    {% for error in get_flashed_messages(category_filter=['error']) %}
+    <li class="alert alert-danger">{{ error }}</li>
+    {% endfor %}
   </ul>
 </div>
-{% endif %}
 


### PR DESCRIPTION
To close #261. Redirects to the report view on a successful recompute, instead of just returning a response from the `/reports/<report_id>/recompute`. This still returns a response from the `/recompute` endpoint on an error, so that errors are displayed. @alorenzo175 any objection to storing/popping messages and errors from a session object? Then we could just set the messages and redirect instead of doing the return another functions result with arguments solution.