### PR TITLE
Set default timerange to display forecasted data

### DIFF
--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -105,6 +105,7 @@ class BaseView(MethodView):
         """
         start_arg = request.args.get('start')
         end_arg = request.args.get('end')
+        utc_now = pd.Timestamp.utcnow()
         try:
             end = pd.Timestamp(end_arg)
         except ValueError:
@@ -112,7 +113,7 @@ class BaseView(MethodView):
         if pd.isnull(end):
             meta_end = self.metadata.get('timerange_end')
             if meta_end is None:
-                end = pd.Timestamp.utcnow()
+                end = utc_now
             else:
                 end = pd.Timestamp(meta_end)
         try:
@@ -120,8 +121,8 @@ class BaseView(MethodView):
         except ValueError:
             start = None
         if pd.isnull(start):
-            if end > pd.Timestamp.utcnow():
-                start = pd.Timestamp.utcnow() - pd.Timedelta('1day')
+            if end > utc_now:
+                start = utc_now - pd.Timedelta('1day')
             else:
                 start = end - pd.Timedelta('3days')
         return start, end

--- a/sfa_dash/blueprints/tests/test_base.py
+++ b/sfa_dash/blueprints/tests/test_base.py
@@ -1,6 +1,9 @@
 import pytest
 
 
+import pandas as pd
+
+
 from sfa_dash.blueprints.base import BaseView
 
 
@@ -24,3 +27,69 @@ def test_flash_errors_list_comp(mocker, app, errors, expected):
         BaseView().flash_api_errors(errors)
     calls = [mocker.call(exp, 'error') for exp in expected]
     flasher.assert_has_calls(calls)
+
+
+@pytest.fixture
+def mocked_now(mocker):
+    mocker.patch('sfa_dash.blueprints.base.pd.Timestamp.utcnow',
+                 return_value=pd.Timestamp('2020-06-01T00:00Z'))
+
+
+@pytest.mark.parametrize('start,end,expected_start,expected_end', [
+    (pd.Timestamp('2019-06-05T00:00Z'), pd.Timestamp('2020-06-05T00:00Z'),
+     pd.Timestamp('2020-05-31T00:00Z'), pd.Timestamp('2020-06-05T00:00Z')),
+    (pd.Timestamp('2020-03-01T00:00Z'), pd.Timestamp('2020-03-30T00:00Z'),
+     pd.Timestamp('2020-03-27T00:00Z'), pd.Timestamp('2020-03-30T00:00Z')),
+    (None, None,
+     pd.Timestamp('2020-05-29T00:00Z'), pd.Timestamp('2020-06-01T00:00Z')),
+])
+def test_parse_start_end_without_request_args(
+        mocker, app, start, end, expected_start, expected_end, mocked_now):
+    with app.test_request_context():
+        view = BaseView()
+        view.metadata = {'timerange_end': end, 'timerange_start': start}
+        start_out, end_out = view.parse_start_end_from_querystring()
+    assert start_out == expected_start
+    assert end_out == expected_end
+
+
+@pytest.mark.parametrize('start,end,expected_start,expected_end', [
+    ('2019-06-05T00:00Z', '2020-06-05T00:00Z',
+     pd.Timestamp('2019-06-05T00:00Z'), pd.Timestamp('2020-06-05T00:00Z')),
+    ('2020-03-01T00:00Z', '2020-03-30T00:00Z',
+     pd.Timestamp('2020-03-01T00:00Z'), pd.Timestamp('2020-03-30T00:00Z')),
+    ('nat', 'nat',
+     pd.Timestamp('2020-05-29T00:00Z'), pd.Timestamp('2020-06-01T00:00Z')),
+])
+def test_parse_start_end_with_request_args(
+        mocker, app, start, end, expected_start, expected_end, mocked_now):
+    with app.test_request_context(query_string={'end': end, 'start': start}):
+        view = BaseView()
+        view.metadata = {}
+        start_out, end_out = view.parse_start_end_from_querystring()
+    assert start_out == expected_start
+    assert end_out == expected_end
+
+
+@pytest.mark.parametrize('arg_key,arg_value,expected_start,expected_end', [
+    ('start', '2020-05-30T00:00Z',
+     pd.Timestamp('2020-05-30T00:00Z'), pd.Timestamp('2020-06-01T00:00Z')),
+    ('end', '2020-03-30T00:00Z',
+     pd.Timestamp('2020-03-27T00:00Z'), pd.Timestamp('2020-03-30T00:00Z')),
+    ('end', '2020-06-05T00:00Z',
+     pd.Timestamp('2020-05-31T00:00Z'), pd.Timestamp('2020-06-05T00:00Z')),
+    ('start', 'nat',
+     pd.Timestamp('2020-05-29T00:00Z'), pd.Timestamp('2020-06-01T00:00Z')),
+    ('end', 'nat',
+     pd.Timestamp('2020-05-29T00:00Z'), pd.Timestamp('2020-06-01T00:00Z')),
+
+])
+def test_parse_start_end_one_request_arg(
+        mocker, app, arg_key, arg_value, expected_start, expected_end,
+        mocked_now):
+    with app.test_request_context(query_string={arg_key: arg_value}):
+        view = BaseView()
+        view.metadata = {}
+        start_out, end_out = view.parse_start_end_from_querystring()
+    assert start_out == expected_start
+    assert end_out == expected_end


### PR DESCRIPTION
Closes #276 

If start and end query parameters are not present and future data exists, displays the future data with a start 1 day prior to the time of the request. Also handles a bug where setting the query parameters to something that parses as NaT got through the logic, causing an error. 