### PR TITLE
Breadcrumb tuples

### DIFF
--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -21,7 +21,7 @@ class AggregatesView(BaseView):
     def set_template_args(self):
         aggregates_list = aggregates.list_metadata()
         self.template_args = {
-            "breadcrumb": self.breadcrumb_html(self.get_breadcrumb_dict()),
+            "breadcrumb": self.breadcrumb_html(self.get_breadcrumb()),
             "aggregates": aggregates_list,
         }
 

--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -1,5 +1,3 @@
-from requests.exceptions import HTTPError
-
 from flask import render_template, url_for, request, redirect
 import pandas as pd
 

--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from requests.exceptions import HTTPError
 
 from flask import render_template, url_for, request, redirect
 import pandas as pd
@@ -13,10 +13,10 @@ from sfa_dash.form_utils.utils import filter_form_fields, flatten_dict
 class AggregatesView(BaseView):
     template = 'data/aggregates.html'
 
-    def get_breadcrumb_dict(self):
-        breadcrumb_dict = OrderedDict()
-        breadcrumb_dict['Aggregates'] = url_for('data_dashboard.aggregates')
-        return breadcrumb_dict
+    def get_breadcrumb(self):
+        breadcrumb = []
+        breadcrumb.append(('Aggregates', url_for('data_dashboard.aggregates')))
+        return breadcrumb
 
     def set_template_args(self):
         aggregates_list = aggregates.list_metadata()
@@ -32,14 +32,16 @@ class AggregateObservationAdditionForm(BaseView):
     template = 'forms/aggregate_observations_addition_form.html'
     metadata_template = 'data/metadata/aggregate_metadata.html'
 
-    def get_breadcrumb_dict(self):
-        breadcrumb_dict = OrderedDict()
-        breadcrumb_dict['Aggregates'] = url_for('data_dashboard.aggregates')
-        breadcrumb_dict[self.metadata['name']] = url_for(
-            'data_dashboard.aggregate_view',
-            uuid=self.metadata['aggregate_id'])
-        breadcrumb_dict['Add Observations'] = ''
-        return breadcrumb_dict
+    def get_breadcrumb(self):
+        breadcrumb = []
+        breadcrumb.append(('Aggregates', url_for('data_dashboard.aggregates')))
+        breadcrumb.append(
+            (self.metadata['name'],
+             url_for('data_dashboard.aggregate_view',
+                     uuid=self.metadata['aggregate_id']))
+        )
+        breadcrumb.append(('Add Observations', ''))
+        return breadcrumb
 
     def get_sites_and_observations(self):
         """Returns a dict of observations mapping uuid to an observation
@@ -95,7 +97,7 @@ class AggregateObservationAdditionForm(BaseView):
             "aggregate": aggregate,
             "metadata": metadata,
             "breadcrumb": self.breadcrumb_html(
-                self.get_breadcrumb_dict()),
+                self.get_breadcrumb()),
         }
         template_arguments.update(kwargs)
         self.template_args = template_arguments
@@ -157,14 +159,16 @@ class AggregateObservationRemovalForm(BaseView):
     template = 'forms/aggregate_observations_removal_form.html'
     metadata_template = 'data/metadata/aggregate_metadata.html'
 
-    def get_breadcrumb_dict(self):
-        breadcrumb_dict = OrderedDict()
-        breadcrumb_dict['Aggregates'] = url_for('data_dashboard.aggregates')
-        breadcrumb_dict[self.metadata['name']] = url_for(
-            'data_dashboard.aggregate_view',
-            uuid=self.metadata['aggregate_id'])
-        breadcrumb_dict['Remove Observation'] = ''
-        return breadcrumb_dict
+    def get_breadcrumb(self):
+        breadcrumb = []
+        breadcrumb.append(('Aggregates', url_for('data_dashboard.aggregates')))
+        breadcrumb.append(
+            (self.metadata['name'],
+             url_for('data_dashboard.aggregate_view',
+                     uuid=self.metadata['aggregate_id']))
+        )
+        breadcrumb.append(('Remove Observation', ''))
+        return breadcrumb
 
     def aggregate_observation_formatter(self, form_data, observation_id):
         formatted = {}
@@ -189,7 +193,7 @@ class AggregateObservationRemovalForm(BaseView):
             "aggregate": aggregate,
             "metadata": metadata,
             "breadcrumb": self.breadcrumb_html(
-                self.get_breadcrumb_dict()),
+                self.get_breadcrumb()),
         }
         try:
             observation = observations.get_metadata(observation_id)
@@ -243,13 +247,17 @@ class AggregateView(BaseView):
         '{cdf_forecasts_url}': 'Probabilistic Forecasts',
     }
 
-    def get_breadcrumb_dict(self):
-        breadcrumb_dict = OrderedDict()
-        breadcrumb_dict['Aggregates'] = url_for('data_dashboard.aggregates')
-        breadcrumb_dict[self.metadata['name']] = url_for(
-            'data_dashboard.aggregate_view',
-            uuid=self.metadata['aggregate_id'])
-        return breadcrumb_dict
+    def get_breadcrumb(self):
+        breadcrumb = []
+        breadcrumb.append(
+            ('Aggregates', url_for('data_dashboard.aggregates')))
+        breadcrumb.append(
+            (self.metadata['name'],
+             url_for(
+                'data_dashboard.aggregate_view',
+                uuid=self.metadata['aggregate_id']))
+        )
+        return breadcrumb
 
     def set_template_args(self, start, end, **kwargs):
         self.template_args.update({
@@ -257,7 +265,7 @@ class AggregateView(BaseView):
                 self.metadata_template, **self.metadata),
             'observations': self.observation_list,
             'breadcrumb': self.breadcrumb_html(
-                self.get_breadcrumb_dict()),
+                self.get_breadcrumb()),
             'metadata': self.safe_metadata(),
             'subnav': self.format_subnav(
                 observations_url=url_for(

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from copy import deepcopy
 
 
@@ -181,14 +180,14 @@ class BaseView(MethodView):
             formatted_subnav[url.format(**kwargs)] = linktext
         return formatted_subnav
 
-    def breadcrumb_html(self, breadcrumb_dict):
+    def breadcrumb_html(self, breadcrumb_list):
         """Build the breadcrumb navigation from an OrderedDict.
 
         Parameters
         ----------
-        breadcrumb_dict: OrderedDict
-            A dictionary of link_text: url. Urls can be relative
-            or absolute. See BaseView.get_breadcrumb_dict for an
+        breadcrumb_list: list of 2-tuples
+            List of (link_text, url) tuples. Urls can be relative
+            or absolute. See BaseView.get_breadcrumb for an
             example of the expected format.
 
         Returns
@@ -199,11 +198,11 @@ class BaseView(MethodView):
             escaping tags.
         """
         breadcrumb = ''
-        for link_text, href in breadcrumb_dict.items():
+        for (link_text, href) in breadcrumb_list:
             breadcrumb += f'/<a href="{href}">{link_text}</a>'
         return breadcrumb
 
-    def get_breadcrumb_dict(self):
+    def get_breadcrumb(self):
         """Creates an ordered dictionary used for building the page's
         breadcrumb. Output can be passed to the BaseView.breadcrumb_html
         function.
@@ -223,7 +222,7 @@ class BaseView(MethodView):
 
         Where the order of the keys is rendered from left to right.
         """
-        return OrderedDict()
+        return []
 
     def flash_api_errors(self, errors):
         """Formats a dictionary of api errors and flashes them to the user on

--- a/sfa_dash/blueprints/data_listing.py
+++ b/sfa_dash/blueprints/data_listing.py
@@ -1,7 +1,6 @@
 """Flask endpoints for listing Observations, Forecasts and CDF Forecasts.
 Defers actual table creation and rendering to DataTables in the util module.
 """
-from collections import OrderedDict
 from flask import render_template, request, url_for
 
 
@@ -36,7 +35,7 @@ class DataListingView(BaseView):
             raise Exception
         self.data_type = data_type
 
-    def get_breadcrumb_dict(self, location_metadata={}):
+    def get_breadcrumb(self, location_metadata={}):
         """Build the breadcrumb dictionary for the listing page.
         Parameters
         ----------
@@ -44,25 +43,38 @@ class DataListingView(BaseView):
             Dict of aggregate or site metadata to use for building
             the breadcrumb.
         """
-        breadcrumb_dict = OrderedDict()
+        breadcrumb = []
         human_label = human_friendly_datatype(self.data_type)
         if 'site_id' in location_metadata:
-            breadcrumb_dict['Sites'] = url_for('data_dashboard.sites')
-            breadcrumb_dict[location_metadata['name']] = url_for(
-                'data_dashboard.site_view', uuid=location_metadata['site_id'])
-            breadcrumb_dict[f'{human_label}s'] = url_for(
-                f'data_dashboard.{self.data_type}s',
-                site_id=location_metadata['site_id'])
+            breadcrumb.append(('Sites', url_for('data_dashboard.sites')))
+            breadcrumb.append(
+                (location_metadata['name'],
+                 url_for(
+                     'data_dashboard.site_view',
+                     uuid=location_metadata['site_id']))
+            )
+            breadcrumb.append(
+                (f'{human_label}s',
+                 url_for(
+                     f'data_dashboard.{self.data_type}s',
+                     site_id=location_metadata['site_id']))
+            )
         elif 'aggregate_id' in location_metadata:
-            breadcrumb_dict['Aggregates'] = url_for(
-                'data_dashboard.aggregates')
-            breadcrumb_dict[location_metadata['name']] = url_for(
-                'data_dashboard.aggregate_view',
-                uuid=location_metadata['aggregate_id'])
-            breadcrumb_dict[f'{human_label}s'] = url_for(
-                f'data_dashboard.{self.data_type}s',
-                aggregate_id=location_metadata['aggregate_id'])
-        return breadcrumb_dict
+            breadcrumb.append(
+                ('Aggregates', url_for('data_dashboard.aggregates')))
+            breadcrumb.append(
+                (location_metadata['name'],
+                 url_for(
+                     'data_dashboard.aggregate_view',
+                     uuid=location_metadata['aggregate_id']))
+            )
+            breadcrumb.append(
+                (f'{human_label}s',
+                 url_for(
+                     f'data_dashboard.{self.data_type}s',
+                     aggregate_id=location_metadata['aggregate_id']))
+            )
+        return breadcrumb
 
     def get_subnav_kwargs(self, site_id=None, aggregate_id=None):
         """Creates a dict to be unpacked as arguments when calling the
@@ -100,6 +112,7 @@ class DataListingView(BaseView):
                 location_metadata = aggregates.get_metadata(aggregate_id)
             self.template_args['breadcrumb'] = self.breadcrumb_html(
                 self.get_breadcrumb_dict(location_metadata))
+
         else:
             self.template_args['page_title'] = 'Forecasts and Observations'
 

--- a/sfa_dash/blueprints/data_listing.py
+++ b/sfa_dash/blueprints/data_listing.py
@@ -111,7 +111,7 @@ class DataListingView(BaseView):
             else:
                 location_metadata = aggregates.get_metadata(aggregate_id)
             self.template_args['breadcrumb'] = self.breadcrumb_html(
-                self.get_breadcrumb_dict(location_metadata))
+                self.get_breadcrumb(location_metadata))
 
         else:
             self.template_args['page_title'] = 'Forecasts and Observations'

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -170,7 +170,7 @@ class SingleObjectView(DataDashView):
         self.template_args['current_path'] = request.path
         self.template_args['subnav'] = self.format_subnav(**kwargs)
         self.template_args['breadcrumb'] = self.breadcrumb_html(
-            self.get_breadcrumb_dict())
+            self.get_breadcrumb())
         self.template_args['metadata_block'] = render_template(
             self.metadata_template,
             **self.metadata)
@@ -283,7 +283,7 @@ class SingleCDFForecastGroupView(SingleObjectView):
         self.template_args['current_path'] = request.path
         self.template_args['subnav'] = self.format_subnav(**kwargs)
         self.template_args['breadcrumb'] = self.breadcrumb_html(
-            self.get_breadcrumb_dict())
+            self.get_breadcrumb())
         self.template_args['metadata_block'] = render_template(
             self.metadata_template,
             **self.metadata)

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -1,6 +1,3 @@
-from collections import OrderedDict
-
-
 from flask import Blueprint, render_template, url_for, request, g
 
 
@@ -86,48 +83,74 @@ class SingleObjectView(DataDashView):
             raise ValueError('Invalid data_type.')
         self.human_label = human_friendly_datatype(self.data_type)
 
-    def get_breadcrumb_dict(self):
-        """See BaseView.get_breadcrumb_dict.
+    def get_breadcrumb(self):
+        """See BaseView.get_breadcrumb.
         """
-        breadcrumb_dict = OrderedDict()
+        breadcrumb = []
         if self.data_type == 'cdf_forecast':
             listing_view = 'cdf_forecast_groups'
         else:
             listing_view = f'{self.data_type}s'
         # Insert site/aggregate link if available
         if self.metadata.get('site') is not None:
-            breadcrumb_dict['Sites'] = url_for('data_dashboard.sites')
-            breadcrumb_dict[self.metadata['site']['name']] = url_for(
-                'data_dashboard.site_view',
-                uuid=self.metadata['site_id'])
-            breadcrumb_dict[f'{self.human_label}s'] = url_for(
-                f'data_dashboard.{listing_view}',
-                site_id=self.metadata['site_id'])
+            breadcrumb.append(('Sites', url_for('data_dashboard.sites')))
+            breadcrumb.append(
+                (self.metadata['site']['name'],
+                 url_for(
+                     'data_dashboard.site_view',
+                     uuid=self.metadata['site_id']))
+            )
+            breadcrumb.append(
+                (f'{self.human_label}s',
+                 url_for(
+                     f'data_dashboard.{listing_view}',
+                     site_id=self.metadata['site_id']))
+            )
         elif self.metadata.get('aggregate') is not None:
-            breadcrumb_dict['Aggregates'] = url_for(
-                'data_dashboard.aggregates')
-            breadcrumb_dict[self.metadata['aggregate']['name']] = url_for(
-                'data_dashboard.aggregate_view',
-                uuid=self.metadata['aggregate_id'])
-            breadcrumb_dict[f'{self.human_label}s'] = url_for(
-                f'data_dashboard.{listing_view}',
-                aggregate_id=self.metadata['aggregate_id'])
+            breadcrumb.append(
+                ('Aggregates',
+                 url_for('data_dashboard.aggregates'))
+            )
+            breadcrumb.append(
+                (self.metadata['aggregate']['name'],
+                 url_for(
+                    'data_dashboard.aggregate_view',
+                    uuid=self.metadata['aggregate_id']))
+            )
+            breadcrumb.append(
+                (f'{self.human_label}s',
+                 url_for(
+                     f'data_dashboard.{listing_view}',
+                     aggregate_id=self.metadata['aggregate_id']))
+            )
         else:
-            breadcrumb_dict[f'{self.human_label}s'] = url_for(
-                f'data_dashboard.{listing_view}')
+            breadcrumb.append(
+                (f'{self.human_label}s',
+                 url_for(
+                     f'data_dashboard.{listing_view}'))
+            )
         # Insert a parent link for cdf_forecasts
         if self.data_type == 'cdf_forecast':
-            breadcrumb_dict[self.metadata['name']] = url_for(
-                f'data_dashboard.cdf_forecast_group_view',
-                uuid=self.metadata['parent'])
-            breadcrumb_dict[self.metadata['constant_value']] = url_for(
-                f'data_dashboard.{self.data_type}_view',
-                uuid=self.metadata[self.id_key])
+            breadcrumb.append(
+                (self.metadata['name'],
+                 url_for(
+                     f'data_dashboard.cdf_forecast_group_view',
+                     uuid=self.metadata['parent']))
+            )
+            breadcrumb.append(
+                (self.metadata['constant_value'],
+                 url_for(
+                     f'data_dashboard.{self.data_type}_view',
+                     uuid=self.metadata[self.id_key]))
+            )
         else:
-            breadcrumb_dict[self.metadata['name']] = url_for(
-                f'data_dashboard.{self.data_type}_view',
-                uuid=self.metadata[self.id_key])
-        return breadcrumb_dict
+            breadcrumb.append(
+                (self.metadata['name'],
+                 url_for(
+                     f'data_dashboard.{self.data_type}_view',
+                     uuid=self.metadata[self.id_key]))
+            )
+        return breadcrumb
 
     def set_template_args(self, uuid, **kwargs):
         """Insert necessary template arguments. See data/asset.html in the
@@ -197,36 +220,54 @@ class SingleCDFForecastGroupView(SingleObjectView):
     def __init__(self):
         pass
 
-    def get_breadcrumb_dict(self, **kwargs):
-        """See BaseView.get_breadcrumb_dict.
+    def get_breadcrumb(self, **kwargs):
+        """See BaseView.get_breadcrumb.
         """
-        breadcrumb_dict = OrderedDict()
+        breadcrumb = []
         if self.metadata.get('site') is not None:
             # If the site is accessible, add /sites/<site name>
             # to the breadcrumb.
-            breadcrumb_dict['Sites'] = url_for('data_dashboard.sites')
-            breadcrumb_dict[self.metadata['site']['name']] = url_for(
-                'data_dashboard.site_view',
-                uuid=self.metadata['site_id'])
-            breadcrumb_dict[f'{self.human_label}s'] = url_for(
-                'data_dashboard.cdf_forecast_groups',
-                site_id=self.metadata['site_id'])
+            breadcrumb.append(('Sites', url_for('data_dashboard.sites')))
+            breadcrumb.append(
+                (self.metadata['site']['name'],
+                 url_for(
+                     'data_dashboard.site_view',
+                     uuid=self.metadata['site_id']))
+            )
+            breadcrumb.append(
+                (f'{self.human_label}s',
+                 url_for(
+                     'data_dashboard.cdf_forecast_groups',
+                     site_id=self.metadata['site_id']))
+            )
         elif self.metadata.get('aggregate') is not None:
-            breadcrumb_dict['Aggregates'] = url_for(
-                'data_dashboard.aggregates')
-            breadcrumb_dict[self.metadata['aggregate']['name']] = url_for(
-                'data_dashboard.aggregate_view',
-                uuid=self.metadata['aggregate_id'])
-            breadcrumb_dict[f'{self.human_label}s'] = url_for(
-                f'data_dashboard.cdf_forecast_groups',
-                aggregate_id=self.metadata['aggregate_id'])
+            breadcrumb.append(
+                ('Aggregates', url_for('data_dashboard.aggregates'))
+            )
+            breadcrumb.append(
+                (self.metadata['aggregate']['name'],
+                 url_for(
+                     'data_dashboard.aggregate_view',
+                     uuid=self.metadata['aggregate_id']))
+            )
+            breadcrumb.append(
+                (f'{self.human_label}s',
+                 url_for(
+                     f'data_dashboard.cdf_forecast_groups',
+                     aggregate_id=self.metadata['aggregate_id']))
+            )
         else:
-            breadcrumb_dict[f'{self.human_label}s'] = url_for(
-                'data_dashboard.cdf_forecast_groups')
-        breadcrumb_dict[self.metadata['name']] = url_for(
-            'data_dashboard.cdf_forecast_group_view',
-            uuid=self.metadata['forecast_id'])
-        return breadcrumb_dict
+            breadcrumb.append(
+                (f'{self.human_label}s',
+                 url_for('data_dashboard.cdf_forecast_groups'))
+            )
+        breadcrumb.append(
+            (self.metadata['name'],
+             url_for(
+                 'data_dashboard.cdf_forecast_group_view',
+                 uuid=self.metadata['forecast_id']))
+        )
+        return breadcrumb
 
     def set_template_args(self, **kwargs):
         """Insert necessary template arguments. See data/asset.html in the

--- a/sfa_dash/blueprints/tests/test_base.py
+++ b/sfa_dash/blueprints/tests/test_base.py
@@ -93,3 +93,15 @@ def test_parse_start_end_one_request_arg(
         start_out, end_out = view.parse_start_end_from_querystring()
     assert start_out == expected_start
     assert end_out == expected_end
+
+
+@pytest.mark.parametrize('bc_list,expected', [
+    ([('dashboard', 'https://dashboard')],
+     '/<a href="https://dashboard">dashboard</a>'),
+    ([('a', 'b'), ('c', 'd'), ('e', 'f')],
+     '/<a href="b">a</a>/<a href="d">c</a>/<a href="f">e</a>'),
+])
+def test_breadcrumb_html(app, bc_list, expected):
+    with app.test_request_context():
+        breadcrumb = BaseView().breadcrumb_html(bc_list)
+        assert breadcrumb == expected

--- a/sfa_dash/tests/views/test_success.py
+++ b/sfa_dash/tests/views/test_success.py
@@ -13,7 +13,7 @@ def test_get_no_arg_routes(client, no_arg_route):
 
 def test_site_filtered_no_args(client, no_arg_route, site_id):
     resp = client.get(no_arg_route, base_url=BASE_URL,
-                      data={'site_id': site_id})
+                      query_string={'site_id': site_id})
     assert resp.status_code == 200
     contains_404 = (
         "<b>404: </b>" in resp.data.decode('utf-8') or
@@ -24,7 +24,7 @@ def test_site_filtered_no_args(client, no_arg_route, site_id):
 
 def test_aggregate_filtered_no_args(client, no_arg_route, aggregate_id):
     resp = client.get(no_arg_route, base_url=BASE_URL,
-                      data={'aggregate_id': aggregate_id})
+                      query_string={'aggregate_id': aggregate_id})
     assert resp.status_code == 200
     contains_404 = (
         "<b>404: </b>" in resp.data.decode('utf-8') or


### PR DESCRIPTION
closes #280 
Updates breadcrumb creation to be based on a list of 2 tuples of `link text, url` to avoid avoid key collisions in the old dictionary design.  