### PR TITLE
Add event to interval_label options

### DIFF
--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -40,4 +40,33 @@ $(document).ready(function(){
             }
         }
     });
+    // Ensure interval_label of 'Event'  when event variable is selected.
+    $('[name="variable"]').change(function(){
+        if (typeof previous_interval_label === 'undefined'){
+            // Set a global variable for remembering the previously selected
+            // value.
+            previous_interval_label = 'beginning';
+        }
+        var interval_label_input = $('[name="interval_label"]');
+        interval_label_input.find('option').prop('hidden', false);
+        if(this.value == 'event'){
+            interval_label_input.val('event');
+            interval_label_input.find('option').not('[value="event"]').prop(
+                'hidden', true);
+        } else {
+            if (interval_label_input.val() != 'event'){
+                // Store a previous non-event value
+                previous_interval_label = interval_label_input.val();
+            } else {
+                // if variable was changed from event, restore the previous
+                // non-event interval label
+                interval_label_input.val(previous_interval_label);
+            }
+            interval_label_input.find('option[value="event"]').prop(
+                'hidden', true);
+        }
+    });
+    // hide interval_label = 'event' by default.
+    $('[name="interval_label"] option[value="event"]').prop(
+                'hidden', true);
 });

--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -42,24 +42,21 @@ $(document).ready(function(){
     });
     // Ensure interval_label of 'Event'  when event variable is selected.
     $('[name="variable"]').change(function(){
-        if (typeof previous_interval_label === 'undefined'){
-            // Set a global variable for remembering the previously selected
-            // value.
-            previous_interval_label = 'beginning';
-        }
         var interval_label_input = $('[name="interval_label"]');
+        if (interval_label_input.val() != 'event'){
+            // Store a previous non-event value
+            previous_interval_label = interval_label_input.val();
+        }
         interval_label_input.find('option').prop('hidden', false);
+
         if(this.value == 'event'){
             interval_label_input.val('event');
             interval_label_input.find('option').not('[value="event"]').prop(
                 'hidden', true);
         } else {
-            if (interval_label_input.val() != 'event'){
-                // Store a previous non-event value
-                previous_interval_label = interval_label_input.val();
-            } else {
-                // if variable was changed from event, restore the previous
-                // non-event interval label
+            if(interval_label_input.val() == 'event'){
+                // if variable was changed from event, and interval label is
+                // still set, restore the previous non-event interval label
                 interval_label_input.val(previous_interval_label);
             }
             interval_label_input.find('option[value="event"]').prop(

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -50,6 +50,13 @@ ALLOWED_QUALITY_FLAGS = {
     'DAYTIME INTERPOLATED VALUES': 'DAYTIME INTERPOLATED VALUES'
 }
 
+INTERVAL_LABEL_OPTIONS = {
+    'beginning': 'Beginning',
+    'ending': 'Ending',
+    'instant': 'Instant',
+    'event': 'Event',
+}
+
 
 def is_allowed(action):
     """Returns if the action is allowed or not on the current object.
@@ -88,4 +95,5 @@ def template_variables():
         'MAX_PLOT_DATAPOINTS': current_app.config['MAX_PLOT_DATAPOINTS'],
         'variable_names': COMMON_NAMES,
         'variable_unit_map': ALLOWED_VARIABLES,
+        'interval_label_options': INTERVAL_LABEL_OPTIONS,
     }

--- a/sfa_dash/templates/forms/aggregate_form.html
+++ b/sfa_dash/templates/forms/aggregate_form.html
@@ -1,5 +1,5 @@
 {% import "forms/form_macros.jinja" as form %}
-{% extends "dash/data.html" %}
+{% extends "forms/base/creation_form.html" %}
 {% block content %}
 <h3>Create New Aggregate</h3>
 <form action="{{ url_for('forms.create_aggregate') }}" method="post" id="aggregate-form">
@@ -13,9 +13,13 @@
         <input type="text" class="form-control" name="description">
      </div>
      <div class="form-element">
-       {{ form.select('Interval label', 'interval_label',
-                      interval_label_options,
-                       'Indicates if a time labels the start or the end of an interval of the aggregate values. Constituent observations will be normalized.') }}
+       {{ form.select(
+              'Interval label', 'interval_label',
+              interval_label_options, null,
+              'Indicates the alignment of time labels, beginning or ending '
+              'of the interval or instantaneous. An interval_label of '
+              '"event" will be set when variable is set to "event". '
+              'Constituent observations will be normalized.') }}
      </div>
      <div class="form-element">
        {{ form.timedelta('Interval length', 'interval_length',

--- a/sfa_dash/templates/forms/aggregate_form.html
+++ b/sfa_dash/templates/forms/aggregate_form.html
@@ -14,9 +14,7 @@
      </div>
      <div class="form-element">
        {{ form.select('Interval label', 'interval_label',
-                      {'beginning': 'Beginning',
-                       'ending': 'Ending',
-                       'instant': 'Instant'},
+                      interval_label_options,
                        'Indicates if a time labels the start or the end of an interval of the aggregate values. Constituent observations will be normalized.') }}
      </div>
      <div class="form-element">

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -44,9 +44,7 @@
 </div>
 <div class="form-element">
   {{ form.select('Interval label', 'interval_label',
-                 {'beginning': 'Beginning',
-                  'ending': 'Ending',
-                  'instant': 'Instant'},
+                 interval_label_options,
                   'Indicates if a time labels the start or the end of an interval.',
                   form_data=form_data) }}
 </div>

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -42,12 +42,9 @@
                     'The length of time that each data point represents. Values must be integers.',
                     form_data=form_data) }}
 </div>
-<div class="form-element">
-  {{ form.select('Interval label', 'interval_label',
-                 interval_label_options,
-                  'Indicates if a time labels the start or the end of an interval.',
-                  form_data=form_data) }}
-</div>
+
+{% include "forms/interval_label.html" %}
+
 <div class="form-element">
   {{ form.select('Interval value type', 'interval_value_type',
                   {"interval_mean": "Mean",

--- a/sfa_dash/templates/forms/forecast_form.html
+++ b/sfa_dash/templates/forms/forecast_form.html
@@ -44,9 +44,7 @@
 </div>
 <div class="form-element">
   {{ form.select('Interval label', 'interval_label',
-                 {'beginning': 'Beginning',
-                  'ending': 'Ending',
-                  'instant': 'Instant'},
+                 interval_label_options,
                   'Indicates if a time labels the start or the end of an interval.',
                   form_data=form_data) }}
 </div>

--- a/sfa_dash/templates/forms/forecast_form.html
+++ b/sfa_dash/templates/forms/forecast_form.html
@@ -42,12 +42,15 @@
                     'The length of time that each data point represents. Values must be integers.',
                     form_data=form_data) }}
 </div>
+{% include "forms/interval_label.html" %}
+{#
 <div class="form-element">
   {{ form.select('Interval label', 'interval_label',
                  interval_label_options,
                   'Indicates if a time labels the start or the end of an interval.',
                   form_data=form_data) }}
 </div>
+#}
 <div class="form-element">
   {{ form.select('Interval value type', 'interval_value_type',
                   {"interval_mean": "Mean",

--- a/sfa_dash/templates/forms/interval_label.html
+++ b/sfa_dash/templates/forms/interval_label.html
@@ -1,0 +1,9 @@
+{# Assumes that form_macros.jinja is available in the `form` template
+   variable
+#}
+<div class="form-element">
+{{ form.select('Interval label', 'interval_label',
+               interval_label_options, null,
+               'Indicates the alignment of time labels, beginning or ending of the interval or instantaneous. An interval_label of "event" will be set when variable is set to "event".',
+               form_data=form_data) }}
+</div>

--- a/sfa_dash/templates/forms/observation_form.html
+++ b/sfa_dash/templates/forms/observation_form.html
@@ -34,9 +34,7 @@
 </div>
 <div class="form-element">
   {{ form.select('Interval label', 'interval_label',
-				 {'beginning': 'Beginning',
-				  'ending': 'Ending',
-				  'instant': 'Instant'},
+				 interval_label_options,
 				  'Indicates if a time labels the start or the end of an interval.') }}
 </div>
 {{ form.extra_parameters() }}

--- a/sfa_dash/templates/forms/observation_form.html
+++ b/sfa_dash/templates/forms/observation_form.html
@@ -32,10 +32,6 @@
                     'The length of time that each data point represents. Values must be integers.',
                     form_data=form_data) }}
 </div>
-<div class="form-element">
-  {{ form.select('Interval label', 'interval_label',
-				 interval_label_options,
-				  'Indicates if a time labels the start or the end of an interval.') }}
-</div>
+{% include "forms/interval_label.html" %}
 {{ form.extra_parameters() }}
 {% endblock %}


### PR DESCRIPTION
closes #295 
Adds 'event' To interval label options and centralizes declaration of these options to `template_globals.py`