### PR TITLE
Reference forecast selection issue

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -681,3 +681,6 @@ div.report-header{
     width: 300px;
     left: calc(-300px + 100%);
 }
+a#ref-clear{
+  color: #007bff;
+}

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -235,8 +235,9 @@ function populateReferenceForecasts(){
         // reference forecast <select> element.
         reference_selector = $('#reference-forecast-select');
         ref_fx.forEach(function(fx){
-            var forecast_id = fx['constant_values'].find(
+            var matching_constant = fx['constant_values'].find(
                 x => x['constant_value'] == constant_value);
+            var forecast_id = matching_constant['forecast_id'];
             reference_selector.append(
                 $('<option></option>')
                     .html(fx['name'])
@@ -822,6 +823,7 @@ function createPairSelector(){
             }else{
                 ref_text = selected_reference_forecast.text;
                 ref_id = selected_reference_forecast.value;
+                console.log(selected_reference_forecast);
             }
             constant_value_select.find('option:selected').each(function(){
                 let forecast_id = $(this).val();

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -823,7 +823,6 @@ function createPairSelector(){
             }else{
                 ref_text = selected_reference_forecast.text;
                 ref_id = selected_reference_forecast.value;
-                console.log(selected_reference_forecast);
             }
             constant_value_select.find('option:selected').each(function(){
                 let forecast_id = $(this).val();

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -586,7 +586,7 @@ function createPairSelector(){
         "reference forecast", "forecast", required=false,
         description='Skill metrics will be calculated for any binary forecasts matching the selection above.');
     refFxSelector.append(
-        $('<a role="button" id="ref-clear">clear reference forecast selection</a>').click(
+        $('<a role="button" id="ref-clear">Clear reference forecast selection</a>').click(
             function(){$('#reference-forecast-select').val('')})
     );
 

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -587,7 +587,7 @@ function createPairSelector(){
         description='Skill metrics will be calculated for any binary forecasts matching the selection above.');
     refFxSelector.append(
         $('<a role="button" id="ref-clear">clear reference forecast selection</a>').click(
-            function(){refFxSelector.val('')})
+            function(){$('#reference-forecast-select').val('')})
     );
 
     var dbSelector = report_utils.deadbandSelector();

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -207,6 +207,7 @@ function populateReferenceForecasts(){
         var axis = constant_value_metadata['axis'];
         var variable = constant_value_metadata['variable'];
         var interval_length = constant_value_metadata['interval_length'];
+        var interval_label = constant_value_metadata['interval_label'];
         var loc = constant_value_metadata[location_key];
 
         // Create a filter function for removing reference forecasts that
@@ -225,6 +226,7 @@ function populateReferenceForecasts(){
                 && e['variable'] == variable
                 && e[location_key] == loc
                 && e['interval_length'] == interval_length
+                && e['interval_label'] == interval_label
                 && constant_values.includes(constant_value);
         };
         var ref_fx = page_data['forecasts'].filter(cv_filter);
@@ -583,6 +585,10 @@ function createPairSelector(){
     var refFxSelector = newSelector(
         "reference forecast", "forecast", required=false,
         description='Skill metrics will be calculated for any binary forecasts matching the selection above.');
+    refFxSelector.append(
+        $('<a role="button" id="ref-clear">clear reference forecast selection</a>').click(
+            function(){refFxSelector.val('')})
+    );
 
     var dbSelector = report_utils.deadbandSelector();
     var constantValueSelector = newConstantValueSelector();
@@ -709,17 +715,6 @@ function createPairSelector(){
                 .attr('data-interval-length', this.interval_length)
                 .attr('data-variable', this.variable));
     });
-    $.each(nonevent_forecasts, function(){
-        ref_forecast_select.append($('<option></option>')
-                .html(this.name)
-                .val(this.forecast_id)
-                .attr('hidden', true)
-                .attr('data-site-id', this.site_id)
-                .attr('data-aggregate-id', this.aggregate_id)
-                .attr('data-interval-length', this.interval_length)
-                .attr('data-variable', this.variable));
-    });
-
     $.each(page_data['aggregates'], function(){
         aggregate_select.append(
             $('<option></option>')

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -187,7 +187,7 @@ function createPairSelector(){
         if (forecast[0]){
             // collect the site or aggregate id, variable and interval_length
             // of the currently selected forecast.
-            if(forecast.data.hasOwnProperty('siteId')){
+            if(forecast.data().hasOwnProperty('siteId')){
                 var site_id = forecast.data().siteId;
             }else{
                 var aggregate_id = forecast.data().aggregateId;
@@ -217,7 +217,6 @@ function createPairSelector(){
                     reference_forecasts.not(
                         `[data-aggregate-id=${aggregate_id}]`));
             }
-
             // Filter out reference forecasts that don't have the same
             // interval length
             mismatched_intervals = reference_forecasts.filter(function(){

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -227,7 +227,6 @@ function createPairSelector(){
             toHide = toHide.add(mismatched_intervals);
 
             var mismatched_labels = reference_forecasts.filter(function(){
-                console.log($(this).data().intervalLabel,' ', interval_label);
                 return $(this).data().inervalLabel != interval_label ||
                     $(this).attr('value') == forecast_select.val();
             });
@@ -360,6 +359,11 @@ function createPairSelector(){
     var fxVariableSelector = report_utils.createVariableSelect();
     var dbSelector = report_utils.deadbandSelector();
     fxSelector.find('.report-field-filters').append(fxVariableSelector);
+
+    refFxSelector.append(
+        $('<a role="button" id="ref-clear">clear reference forecast selection</a>').click(
+            function(){refFxSelector.val('');})
+    );
 
     // Buttons for adding an obs/fx pair for observations or aggregates
     var addObsButton = $('<a role="button" class="btn btn-primary" id="add-obs-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -194,6 +194,7 @@ function createPairSelector(){
             }
             var variable = forecast.data().variable;
             var interval_length = forecast.data().intervalLength;
+            var interval_label = forecast.data().intervalLabel;
 
             // hide the "please select forecast" prompt"
             $('#no-reference-forecast-forecast-selection').attr('hidden', true);
@@ -219,11 +220,18 @@ function createPairSelector(){
             }
             // Filter out reference forecasts that don't have the same
             // interval length
-            mismatched_intervals = reference_forecasts.filter(function(){
+            var mismatched_intervals = reference_forecasts.filter(function(){
                 return $(this).data().intervalLength != interval_length ||
                     $(this).attr('value') == forecast_select.val();
             });
             toHide = toHide.add(mismatched_intervals);
+
+            var mismatched_labels = reference_forecasts.filter(function(){
+                console.log($(this).data().intervalLabel,' ', interval_label);
+                return $(this).data().inervalLabel != interval_label ||
+                    $(this).attr('value') == forecast_select.val();
+            });
+            toHide = toHide.add(mismatched_labels);
         }else{
             // No forecast was selected, hide all reference forecasts
             // and display a message.
@@ -437,6 +445,7 @@ function createPairSelector(){
                 .attr('data-site-id', this.site_id)
                 .attr('data-aggregate-id', this.aggregate_id)
                 .attr('data-interval-length', this.interval_length)
+                .attr('data-interval-label', this.interval_label)
                 .attr('data-variable', this.variable));
     });
     $.each(nonevent_forecasts, function(){
@@ -447,6 +456,7 @@ function createPairSelector(){
                 .attr('data-site-id', this.site_id)
                 .attr('data-aggregate-id', this.aggregate_id)
                 .attr('data-interval-length', this.interval_length)
+                .attr('data-interval-label', this.interval_label)
                 .attr('data-variable', this.variable));
     });
     $.each(page_data['aggregates'], function(){

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -361,7 +361,7 @@ function createPairSelector(){
     fxSelector.find('.report-field-filters').append(fxVariableSelector);
 
     refFxSelector.append(
-        $('<a role="button" id="ref-clear">clear reference forecast selection</a>').click(
+        $('<a role="button" id="ref-clear">Clear reference forecast selection</a>').click(
             function(){$('#reference-forecast-select').val('');})
     );
 

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -227,7 +227,7 @@ function createPairSelector(){
             toHide = toHide.add(mismatched_intervals);
 
             var mismatched_labels = reference_forecasts.filter(function(){
-                return $(this).data().inervalLabel != interval_label ||
+                return $(this).data().intervalLabel != interval_label ||
                     $(this).attr('value') == forecast_select.val();
             });
             toHide = toHide.add(mismatched_labels);
@@ -362,7 +362,7 @@ function createPairSelector(){
 
     refFxSelector.append(
         $('<a role="button" id="ref-clear">clear reference forecast selection</a>').click(
-            function(){refFxSelector.val('');})
+            function(){$('#reference-forecast-select').val('');})
     );
 
     // Buttons for adding an obs/fx pair for observations or aggregates


### PR DESCRIPTION
closes #306 
closes #304

Corrects the check for site_id vs aggregate id when deciding how to filter deterministic forecasts by location. Populates reference forecasts with the valid UUID of the matching constant value instead of the Object that contained it.