### PR TITLE
Forecast fill

### DIFF
--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -72,6 +72,9 @@ def display_timedelta(minutes):
     time_string = ' '.join(time_elements)
     return time_string
 
+def is_number(num):
+    return str(num).isnumeric()
+
 
 def register_jinja_filters(app):
     app.jinja_env.filters['convert_varname'] = api_to_dash_varname
@@ -79,3 +82,4 @@ def register_jinja_filters(app):
     app.jinja_env.filters['display_timedelta'] = display_timedelta
     app.jinja_env.filters['convert_data_type'] = human_friendly_datatype
     app.jinja_env.filters['format_datetime'] = format_datetime
+    app.jinja_env.filters['is_number'] = is_number

--- a/sfa_dash/form_utils/converters.py
+++ b/sfa_dash/form_utils/converters.py
@@ -597,7 +597,7 @@ class ReportConverter(FormConverter):
         form_params['metrics'] = report_parameters.get('metrics', [])
         form_params['period-start'] = report_parameters['start']
         form_params['period-end'] = report_parameters['end']
-        form_params['costs'] = report_parameters.get('costs', [])
+        form_params['costs'] = report_parameters['costs']
         form_params['forecast_fill_method'] = report_parameters.get(
             'forecast_fill_method',
             'drop'

--- a/sfa_dash/form_utils/converters.py
+++ b/sfa_dash/form_utils/converters.py
@@ -557,6 +557,13 @@ class ReportConverter(FormConverter):
             return params
 
     @classmethod
+    def parse_fill_method(cls, form_dict):
+        fill_method = form_dict.get('forecast_fill_method', 'drop')
+        if fill_method == 'provided':
+            fill_method = form_dict['provided_forecast_fill_method']
+        return fill_method
+
+    @classmethod
     def formdata_to_payload(cls, form_dict):
         report_params = {}
         report_params['name'] = form_dict['name']
@@ -569,6 +576,8 @@ class ReportConverter(FormConverter):
         report_params['filters'] = cls.parse_form_filters(form_dict)
         report_params['start'] = form_dict['period-start']
         report_params['end'] = form_dict['period-end']
+        report_params['forecast_fill_method'] = cls.parse_fill_method(
+            form_dict)
         report_params = cls.apply_crps(report_params)
         report_dict = {'report_parameters': report_params}
         if len(costs) > 0:
@@ -588,7 +597,11 @@ class ReportConverter(FormConverter):
         form_params['metrics'] = report_parameters.get('metrics', [])
         form_params['period-start'] = report_parameters['start']
         form_params['period-end'] = report_parameters['end']
-        form_params['costs'] = report_parameters['costs']
+        form_params['costs'] = report_parameters.get('costs', [])
+        form_params['forecast_fill_method'] = report_parameters.get(
+            'forecast_fill_method',
+            'drop'
+        )
 
         # Objects pairs are left in the api format for parsing in javascript
         # see sfa_dash/static/js/report-utilities.js fill_object_pairs function

--- a/sfa_dash/static/js/event-report-form-handling.js
+++ b/sfa_dash/static/js/event-report-form-handling.js
@@ -287,4 +287,5 @@ $(document).ready(function() {
     report_utils.registerDatetimeValidator('period-start');
     report_utils.registerDatetimeValidator('period-end')
     report_utils.fill_existing_pairs();
+    report_utils.register_forecast_fill_method_validator('event');
 });

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -914,4 +914,5 @@ $(document).ready(function() {
     unpack_constant_values();
     report_utils.fill_existing_pairs();
     report_utils.register_uncertainty_handler('#observation-select');
+    report_utils.register_forecast_fill_method_validator();
 });

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -914,5 +914,5 @@ $(document).ready(function() {
     unpack_constant_values();
     report_utils.fill_existing_pairs();
     report_utils.register_uncertainty_handler('#observation-select');
-    report_utils.register_forecast_fill_method_validator();
+    report_utils.register_forecast_fill_method_validator('probabilistic');
 });

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -577,5 +577,5 @@ $(document).ready(function() {
     report_utils.fill_existing_pairs();
     report_utils.register_uncertainty_handler('#observation-select');
     report_utils.insert_cost_widget();
-    report_utils.register_forecast_fill_method_validator();
+    report_utils.register_forecast_fill_method_validator('deterministic');
 });

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -577,4 +577,5 @@ $(document).ready(function() {
     report_utils.fill_existing_pairs();
     report_utils.register_uncertainty_handler('#observation-select');
     report_utils.insert_cost_widget();
+    report_utils.register_forecast_fill_method_validator();
 });

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -1421,3 +1421,17 @@ report_utils.help_popup = function(help_name, help_text){
     var help_box = $(`<span class="${help_name}-help-text form-text text-muted help-text collapse" aria-hidden="">${help_text}</span>`);
     return [help_button, help_box]
 }
+report_utils.register_forecast_fill_method_validator = function(
+    forecast_type='deterministic'){
+    var forecast_fill = $('[name=forecast_fill_method]')
+    forecast_fill.change(function(){
+        if (this.value == 'provided'){
+            $('[name=provided_forecast_fill_method]').prop('disabled', false);
+        } else {
+            $('[name=provided_forecast_fill_method]').prop('disabled', true);
+        }
+    });
+    if (forecast_type == 'event'){
+        forecast_fill.prop('step', 1).prop('min', 0).prop('max', 1);
+    }
+}

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -1432,6 +1432,9 @@ report_utils.register_forecast_fill_method_validator = function(
         }
     });
     if (forecast_type == 'event'){
-        forecast_fill.prop('step', 1).prop('min', 0).prop('max', 1);
+        $('[name=provided_forecast_fill_method]')
+            .prop('step', 1)
+            .prop('min', 0)
+            .prop('max', 1);
     }
 }

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -113,8 +113,8 @@
        {% endif %}
        <input name="forecast_fill_method" type="radio" value="drop" {% if selected_fill_method == 'drop' %}checked{% endif %}>Drop<br>
        <input name="forecast_fill_method" type="radio" value="forward" {% if selected_fill_method == 'forward' %}checked{% endif %}>Forward<br>
-       <input name="forecast_fill_method" type="radio" value="provided" {% if selected_fill_method is float %}checked{% endif %}>Provided Value
-       <input name="provided_forecast_fill_method" type="number" step="any" required {% if selected_fill_method is float %}value="{{selected_fill_method}}"{% else %}disabled{% endif %}>
+       <input name="forecast_fill_method" type="radio" value="provided" {% if selected_fill_method | is_number %}checked{% endif %}>Provided Value
+       <input name="provided_forecast_fill_method" type="number" step="any" required {% if selected_fill_method | is_number %}value="{{selected_fill_method}}"{% else %}disabled{% endif %}>
      </div>
      {% endblock %}
     {{ form.token() }}

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -114,7 +114,7 @@
        <input name="forecast_fill_method" type="radio" value="drop" {% if selected_fill_method == 'drop' %}checked{% endif %}>Drop<br>
        <input name="forecast_fill_method" type="radio" value="forward" {% if selected_fill_method == 'forward' %}checked{% endif %}>Forward<br>
        <input name="forecast_fill_method" type="radio" value="provided" {% if selected_fill_method is float %}checked{% endif %}>Provided Value
-       <input name="provided_forecast_fill_method" type="number" step="any" required {% if selected_fill_method is float %}value="selected_fill_method"{% else %}disabled{% endif %}>
+       <input name="provided_forecast_fill_method" type="number" step="any" required {% if selected_fill_method is float %}value="{{selected_fill_method}}"{% else %}disabled{% endif %}>
      </div>
      {% endblock %}
     {{ form.token() }}

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -103,6 +103,16 @@
        {% endfor %}
      </div>
      {% endblock %}
+     {% block forecast_fill_method_field %}
+     <div class="form-element full-width">
+       <label>Forecast Fill Method</label><br>
+       {% set selected_fill_method = form_data['report_parameters'].get('forecast_fill_method', 'drop') %}
+       <input name="forecast_fill_method" type="radio" value="drop" {% if selected_fill_method == 'drop' %}checked{% endif %}>Drop<br>
+       <input name="forecast_fill_method" type="radio" value="forward" {% if selected_fill_method == 'forward' %}checked{% endif %}>Forward<br>
+       <input name="forecast_fill_method" type="radio" value="provided" {% if selected_fill_method is float %}checked{% endif %}>Provided Value
+       <input name="provided_forecast_fill_method" type="number" step="any" {% if selected_fill_method is float %}value="selected_fill_method"{% else %}disabled{% endif %}>
+     </div>
+     {% endblock %}
     {{ form.token() }}
   </div>
 </form>

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -106,11 +106,15 @@
      {% block forecast_fill_method_field %}
      <div class="form-element full-width">
        <label>Forecast Fill Method</label><br>
+       {% if form_data %}
        {% set selected_fill_method = form_data['report_parameters'].get('forecast_fill_method', 'drop') %}
+       {% else %}
+       {% set selected_fill_method = 'drop' %}
+       {% endif %}
        <input name="forecast_fill_method" type="radio" value="drop" {% if selected_fill_method == 'drop' %}checked{% endif %}>Drop<br>
        <input name="forecast_fill_method" type="radio" value="forward" {% if selected_fill_method == 'forward' %}checked{% endif %}>Forward<br>
        <input name="forecast_fill_method" type="radio" value="provided" {% if selected_fill_method is float %}checked{% endif %}>Provided Value
-       <input name="provided_forecast_fill_method" type="number" step="any" {% if selected_fill_method is float %}value="selected_fill_method"{% else %}disabled{% endif %}>
+       <input name="provided_forecast_fill_method" type="number" step="any" required {% if selected_fill_method is float %}value="selected_fill_method"{% else %}disabled{% endif %}>
      </div>
      {% endblock %}
     {{ form.token() }}

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -112,7 +112,7 @@
        {% set selected_fill_method = 'drop' %}
        {% endif %}
        All missing or NaN forecast intervals should be:<br>
-       <input name="forecast_fill_method" type="radio" value="drop" {% if selected_fill_method == 'drop' %}checked{% endif %}>dropped from the analysis<br>
+       <input name="forecast_fill_method" type="radio" value="drop" {% if selected_fill_method == 'drop' %}checked{% endif %}> dropped from the analysis<br>
        <input name="forecast_fill_method" type="radio" value="forward" {% if selected_fill_method == 'forward' %}checked{% endif %}> filled forward with last valid forecast value<br>
        <input name="forecast_fill_method" type="radio" value="provided" {% if selected_fill_method | is_number %}checked{% endif %}> filled with
        <input name="provided_forecast_fill_method" type="number" step="any" required {% if selected_fill_method | is_number %}value="{{selected_fill_method}}"{% else %}disabled{% endif %}>

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -111,9 +111,10 @@
        {% else %}
        {% set selected_fill_method = 'drop' %}
        {% endif %}
-       <input name="forecast_fill_method" type="radio" value="drop" {% if selected_fill_method == 'drop' %}checked{% endif %}>Drop<br>
-       <input name="forecast_fill_method" type="radio" value="forward" {% if selected_fill_method == 'forward' %}checked{% endif %}>Forward<br>
-       <input name="forecast_fill_method" type="radio" value="provided" {% if selected_fill_method | is_number %}checked{% endif %}>Provided Value
+       All missing or NaN forecast intervals should be:<br>
+       <input name="forecast_fill_method" type="radio" value="drop" {% if selected_fill_method == 'drop' %}checked{% endif %}>dropped from the analysis<br>
+       <input name="forecast_fill_method" type="radio" value="forward" {% if selected_fill_method == 'forward' %}checked{% endif %}> filled forward with last valid forecast value<br>
+       <input name="forecast_fill_method" type="radio" value="provided" {% if selected_fill_method | is_number %}checked{% endif %}> filled with
        <input name="provided_forecast_fill_method" type="number" step="any" required {% if selected_fill_method | is_number %}value="{{selected_fill_method}}"{% else %}disabled{% endif %}>
      </div>
      {% endblock %}


### PR DESCRIPTION
Adds a forecast fill field at the end of all of the report forms. UI is simple radio buttons as suggested by @wholmgren.
closes #292 

When `drop` or `forward` options  are selected, the field for providing a value is disabled.
![Screenshot from 2020-07-01 16-54-07](https://user-images.githubusercontent.com/21206164/86301753-843ba000-bbbb-11ea-9102-048a7fa72c5b.png)

When the 'filled with' option is selected the field is activated and required. There is a bit of js that sets the min max and step to 0, 1, and 1 respectively for events.
![Screenshot from 2020-07-01 16-53-59](https://user-images.githubusercontent.com/21206164/86301811-b0572100-bbbb-11ea-94a6-b9808096cab5.png)

