### PR TITLE
Report clone button

### DIFF
--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -72,6 +72,7 @@ def display_timedelta(minutes):
     time_string = ' '.join(time_elements)
     return time_string
 
+
 def is_number(num):
     return str(num).isnumeric()
 

--- a/sfa_dash/form_utils/converters.py
+++ b/sfa_dash/form_utils/converters.py
@@ -597,7 +597,7 @@ class ReportConverter(FormConverter):
         form_params['metrics'] = report_parameters.get('metrics', [])
         form_params['period-start'] = report_parameters['start']
         form_params['period-end'] = report_parameters['end']
-        form_params['costs'] = report_parameters['costs']
+        form_params['costs'] = report_parameters.get('costs', [])
         form_params['forecast_fill_method'] = report_parameters.get(
             'forecast_fill_method',
             'drop'

--- a/sfa_dash/form_utils/converters.py
+++ b/sfa_dash/form_utils/converters.py
@@ -7,6 +7,7 @@ the converter is expected to parse.
 """
 from abc import ABC, abstractmethod
 from functools import reduce
+from math import isinf
 
 
 from sfa_dash.form_utils import utils
@@ -564,6 +565,23 @@ class ReportConverter(FormConverter):
         return fill_method
 
     @classmethod
+    def stringify_infinite_error_ranges(cls, payload_costs):
+        """Necessary for loading data into front end javascript. The js value
+        Infinity is not valid JSON, and must be manually converted to the
+        string "Infinity".
+        """
+        for cost in payload_costs:
+            if cost['type'] == 'errorband':
+                for band in cost['parameters']['bands']:
+                    for i, bound in enumerate(band['error_range']):
+                        if isinf(float(bound)):
+                            if float(bound) > 0:
+                                band['error_range'][i] = "Infinity"
+                            else:
+                                band['error_range'][i] = "-Infinity"
+        return payload_costs
+
+    @classmethod
     def formdata_to_payload(cls, form_dict):
         report_params = {}
         report_params['name'] = form_dict['name']
@@ -597,7 +615,8 @@ class ReportConverter(FormConverter):
         form_params['metrics'] = report_parameters.get('metrics', [])
         form_params['period-start'] = report_parameters['start']
         form_params['period-end'] = report_parameters['end']
-        form_params['costs'] = report_parameters.get('costs', [])
+        form_params['costs'] = cls.stringify_infinite_error_ranges(
+            report_parameters.get('costs', []))
         form_params['forecast_fill_method'] = report_parameters.get(
             'forecast_fill_method',
             'drop'

--- a/sfa_dash/form_utils/tests/test_converter.py
+++ b/sfa_dash/form_utils/tests/test_converter.py
@@ -551,3 +551,21 @@ def test_report_converter_parse_form_fill_method(form_vals, expected):
     form_data = ImmutableMultiDict(form_vals)
     parsed = converters.ReportConverter.parse_fill_method(form_data)
     assert parsed == expected
+
+
+@pytest.mark.parametrize('error_range,expected', [
+    ([1, float('inf')], [1, "Infinity"]),
+    ([float('-inf'), 0], ["-Infinity", 0]),
+    ([-5, 5], [-5, 5]),
+])
+def test_report_converter_stringify_infinity(error_range, expected):
+    result = converters.ReportConverter.stringify_infinite_error_ranges(
+        [{'type': 'errorband',
+          'parameters': {
+              'bands': [{
+                  'error_range': error_range}
+                ]
+            }}
+         ]
+    )
+    assert result[0]['parameters']['bands'][0]['error_range'] == expected

--- a/sfa_dash/templates/data/intermediate_report.html
+++ b/sfa_dash/templates/data/intermediate_report.html
@@ -8,6 +8,7 @@
 <h1 id="report-title">{{ report['report_parameters']['name'] }}</h1>
 {% endif %}
 {% if is_allowed('update') %}<a class="btn btn-primary btn-sm" href="{{url_for('forms.recompute_report', uuid=report['report_id'])}}">Recompute report</a>{% endif %}
+{% if is_allowed('read') %}<a class="btn btn-primary btn-sm" href="{{url_for('forms.clone_report', uuid=report['report_id'])}}">Copy Report</a>{% endif %}
 </div>
 {% endblock %}
 {% block download %}

--- a/sfa_dash/templates/data/intermediate_report.html
+++ b/sfa_dash/templates/data/intermediate_report.html
@@ -8,7 +8,7 @@
 <h1 id="report-title">{{ report['report_parameters']['name'] }}</h1>
 {% endif %}
 {% if is_allowed('update') %}<a class="btn btn-primary btn-sm" href="{{url_for('forms.recompute_report', uuid=report['report_id'])}}">Recompute report</a>{% endif %}
-{% if is_allowed('read') %}<a class="btn btn-primary btn-sm" href="{{url_for('forms.clone_report', uuid=report['report_id'])}}">Copy Report</a>{% endif %}
+{% if is_allowed('read') %}<a class="btn btn-primary btn-sm" href="{{url_for('forms.clone_report', uuid=report['report_id'])}}">Clone report parameters</a>{% endif %}
 </div>
 {% endblock %}
 {% block download %}


### PR DESCRIPTION
Adds a "Copy Report" button next to recompute. I found a bug in the jinja `tojson` filter that serializes infinity as the javascript global `Infinity` which was causing a crash, hence the new function `stringify_infinite_error_ranges`. I also realized that the `.get('costs', [])` in `ReportConverter.api_payload_to_formdata` was necessary since it is an optional API parameter.

Screenshot of placement.
![Screenshot from 2020-07-02 13-54-19](https://user-images.githubusercontent.com/21206164/86408432-da681c00-bc6b-11ea-8238-db06a84bcd1b.png)

closes #312 