### PR TITLE
fire forecast filtering when units are set

### DIFF
--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -62,7 +62,7 @@ function pairWrapper(truth_type, truth_id, truth_name, fx_id, fx_name,
         if ($('.object-pair-list .object-pair').length == 0){
             // If the last pairs were removed, unset the unit constraint
             $('.empty-reports-list')[0].hidden = false;
-            report_utils.unset_units();
+            report_utils.unset_units(filterForecasts);
         }
         report_utils.toggle_reference_dependent_metrics();
     });
@@ -148,7 +148,7 @@ function addPair(
         if ($('.object-pair-list .object-pair').length == 0){
             // if the last pairs were removed, remove the units constraint
             $('.empty-reports-list')[0].hidden = false;
-            report_utils.unset_units();
+            report_utils.unset_units(filterForecasts);
         }
         report_utils.toggle_reference_dependent_metrics();
     });
@@ -785,7 +785,7 @@ function createPairSelector(){
             });
 
             var variable = selected_forecast.dataset.variable;
-            report_utils.set_units(variable);
+            report_utils.set_units(variable, filterForecasts);
             $(".empty-reports-list").attr('hidden', 'hidden');
             forecast_select.css('border', '');
             observation_select.css('border', '');
@@ -852,7 +852,7 @@ function createPairSelector(){
                 );
             });
             var variable = selected_forecast.dataset.variable;
-            report_utils.set_units(variable);
+            report_utils.set_units(variable, filterForecasts);
 
             $(".empty-reports-list")[0].hidden = true;
             forecast_select.css('border', '');

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -52,7 +52,7 @@ function addPair(
         new_object_pair.remove();
         if ($('.object-pair-list .object-pair').length == 0){
             $('.empty-reports-list')[0].hidden = false;
-            report_utils.unset_units();
+            report_utils.unset_units(filterForecasts);
         }
         report_utils.toggle_reference_dependent_metrics();
     });
@@ -510,7 +510,7 @@ function createPairSelector(){
                     deadband_values[1],
             );
             var variable = selected_forecast.dataset.variable;
-            report_utils.set_units(variable);
+            report_utils.set_units(variable, filterForecasts);
             $(".empty-reports-list").attr('hidden', 'hidden');
             forecast_select.css('border', '');
             observation_select.css('border', '');
@@ -551,7 +551,7 @@ function createPairSelector(){
                            null,
             );
             var variable = selected_forecast.dataset.variable;
-            report_utils.set_units(variable);
+            report_utils.set_units(variable, filterForecasts);
 
             $(".empty-reports-list")[0].hidden = true;
             forecast_select.css('border', '');

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -152,14 +152,17 @@ report_utils.toggle_reference_dependent_metrics = function(){
 current_units = null;
 
 
-report_utils.unset_units = function(){
+report_utils.unset_units = function(filter_callback=null){
     current_units = null;
     // Call to setVariables to repopulate the options in the Variable <select>
     // element.
     report_utils.setVariables()
+    if (filter_callback){
+        filter_callback();
+    }
 }
 
-report_utils.set_units = function(variable){
+report_utils.set_units = function(variable, filter_callback=null){
     /* Sets the global current_units based on the variable parameter. This is
      * to enforce similar units across all object pairs.
      */
@@ -168,6 +171,9 @@ report_utils.set_units = function(variable){
         current_units = units;
     }
     report_utils.setVariables();
+    if (filter_callback){
+        filter_callback();
+    }
 }
 
 report_utils.searchObjects = function(object_type, object_id){


### PR DESCRIPTION
Closes #314 
Adds a callback argument to the `report_utils.set_units` and `report_utils.unset_units` that will be called after setting the units/variables. The forecast filtering functions are passed in when setting/unsetting the units.