### PR TITLE
Fix climate zone filtering

### DIFF
--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -84,10 +84,10 @@ def climate_zone_links(zones):
             return f'<a href="https://solarforecastarbiter.org/climatezones/#region{zone_number}">{zone_name}</a>'  # noqa: E501
         else:
             return zone_name
-    if not zones:
-        return ["No Climate Zone"]
-    else:
+    if zones:
         return [reference_zone_link(zone) for zone in zones]
+    else:
+        return ["No Climate Zone"]
 
 
 def register_jinja_filters(app):

--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -85,9 +85,9 @@ def climate_zone_links(zones):
         else:
             return zone_name
     if not zones:
-        return "No Climate Zone"
+        return ["No Climate Zone"]
     else:
-        return ', '.join([reference_zone_link(zone) for zone in zones])
+        return [reference_zone_link(zone) for zone in zones]
 
 
 def register_jinja_filters(app):

--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -77,6 +77,19 @@ def is_number(num):
     return str(num).isnumeric()
 
 
+def climate_zone_links(zones):
+    def reference_zone_link(zone_name):
+        if 'Reference Region' in zone_name:
+            zone_number = zone_name.split(' ')[-1]
+            return f'<a href="https://solarforecastarbiter.org/climatezones/#region{zone_number}">{zone_name}</a>'  # noqa: E501
+        else:
+            return zone_name
+    if not zones:
+        return "No Climate Zone"
+    else:
+        return ', '.join([reference_zone_link(zone) for zone in zones])
+
+
 def register_jinja_filters(app):
     app.jinja_env.filters['convert_varname'] = api_to_dash_varname
     app.jinja_env.filters['var_to_units'] = api_varname_to_units
@@ -84,3 +97,4 @@ def register_jinja_filters(app):
     app.jinja_env.filters['convert_data_type'] = human_friendly_datatype
     app.jinja_env.filters['format_datetime'] = format_datetime
     app.jinja_env.filters['is_number'] = is_number
+    app.jinja_env.filters['climate_zone_links'] = climate_zone_links

--- a/sfa_dash/static/js/table-search.js
+++ b/sfa_dash/static/js/table-search.js
@@ -129,9 +129,11 @@ $(document).ready(function() {
 
             // Create a Set of options from the contents of each of the column's
             // <td> elements
-            var availableOptions = new Set($(`.${columnName}-column`).map(function(){
-                return $(this).text();
-            }));
+            var availableOptions = Array.from(
+                new Set($(`.${columnName}-column`).map(function(){
+                    return $(this).text();
+                }))
+            ).sort();
 
             // Collapsible div containing the list of checkboxes, this is the
             // target of the button that the table header was wrapped in.

--- a/sfa_dash/templates/data/metadata/site_metadata.html
+++ b/sfa_dash/templates/data/metadata/site_metadata.html
@@ -11,8 +11,9 @@
   {% if climate_zones %}
   <li><b>Climate Zones:</b>
     <ul>
-      {% for zone in climate_zones %}
-      <li>{{ zone }}</li>
+      {% set zones = climate_zones | climate_zone_links %}
+      {% for zone in zones %}
+      <li>{{ zone | safe }}</li>
       {% endfor %}
     </ul>
   </li>

--- a/sfa_dash/templates/data/table/site_table.html
+++ b/sfa_dash/templates/data/table/site_table.html
@@ -20,7 +20,12 @@
     <tr>
       <td class="name-column"><a href="{{ row['link'] }}">{{ row['name'] }}</a></td>
       <td class="provider-column">{{ row['provider'] }}</td>
-      <td class="climate-zones-column">{{ row['climate_zones'] | join(', ') }}</td>
+      {% if row['climate_zones'] |length > 0 %}
+      {% set climate_zones = row['climate_zones'] |join(', ') %}
+      {% else %}
+      {% set climate_zones = "No Climate Zone" %}
+      {% endif %}
+      <td class="climate-zones-column">{{ climate_zones }}</td>
     </tr>
 	{% endfor %}
   </tbody>

--- a/sfa_dash/templates/data/table/site_table.html
+++ b/sfa_dash/templates/data/table/site_table.html
@@ -20,12 +20,7 @@
     <tr>
       <td class="name-column"><a href="{{ row['link'] }}">{{ row['name'] }}</a></td>
       <td class="provider-column">{{ row['provider'] }}</td>
-      {% if row['climate_zones'] |length > 0 %}
-      {% set climate_zones = row['climate_zones'] |join(', ') %}
-      {% else %}
-      {% set climate_zones = "No Climate Zone" %}
-      {% endif %}
-      <td class="climate-zones-column">{{ climate_zones }}</td>
+      <td class="climate-zones-column">{{ row['climate_zones'] | climate_zone_links | safe}}</td>
     </tr>
 	{% endfor %}
   </tbody>

--- a/sfa_dash/templates/data/table/site_table.html
+++ b/sfa_dash/templates/data/table/site_table.html
@@ -20,7 +20,7 @@
     <tr>
       <td class="name-column"><a href="{{ row['link'] }}">{{ row['name'] }}</a></td>
       <td class="provider-column">{{ row['provider'] }}</td>
-      <td class="climate-zones-column">{{ row['climate_zones'] | climate_zone_links | safe}}</td>
+      <td class="climate-zones-column">{{ row['climate_zones'] | climate_zone_links | join(', ') | safe }}</td>
     </tr>
 	{% endfor %}
   </tbody>


### PR DESCRIPTION
closes #318 
closes #321 
Inserts "No Climate Zone" when a site's climate_zones attribute is an empty list, so that the value can be filtered on. This also sorts all of the filter options for *every* table filter.
![Screenshot from 2020-07-06 16-30-13](https://user-images.githubusercontent.com/21206164/86667074-1f5ebc00-bfa6-11ea-9af3-16af75df4c85.png)
