### PR TITLE
Fix permissions with object type 'report' 

### DIFF
--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -655,12 +655,11 @@ class PermissionObjectAddition(PermissionView):
             api = self.get_api_handler(permission['object_type'])
             perm_objects = list(permission['objects'].keys())
 
-            if data_type == 'report':
-                all_objects = api.list_metadata()
-                all_objects = self.flatten_reports(all_objects)
-            else:
-                all_objects = api.list_metadata()
+            all_objects = api.list_metadata()
             all_objects = self.filter_by_org(all_objects, 'provider')
+
+            if data_type == 'report':
+                all_objects = self.flatten_reports(all_objects)
             # remove any objects alread on the permission
             object_id_key = f"{data_type}_id"
             all_objects = [obj for obj in all_objects

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -66,9 +66,9 @@ class AdminView(BaseView):
         self.template_args = {'subnav': self.format_subnav(**subnav_kwargs)}
 
     def flatten_reports(self, report_list):
-        """Takes a list of report objects from the api and updates the
-        top-level keys with the contents of 'report_parameters' for each
-        report.
+        """Takes a list of report metadata dictionaries and moved the `name`
+        field to the top-level dictionary and removes unneeded report
+        parameters and raw report.
         """
         for report in report_list:
             report.update({'name': report.pop('report_parameters')['name']})

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -72,6 +72,7 @@ class AdminView(BaseView):
         """
         for report in report_list:
             report.update({'name': report.pop('report_parameters')['name']})
+            report.pop('raw_report', None)
         return report_list
 
     def get(self):

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -70,10 +70,9 @@ class AdminView(BaseView):
         top-level keys with the contents of 'report_parameters' for each
         report.
         """
-        reports = [report.copy() for report in report_list]
-        for report in reports:
-            report.update(report.pop('report_parameters'))
-        return reports
+        for report in report_list:
+            report.update({'name': report.pop('report_parameters')['name']})
+        return report_list
 
     def get(self):
         self.set_template_args()
@@ -660,7 +659,7 @@ class PermissionObjectAddition(PermissionView):
 
             if data_type == 'report':
                 all_objects = self.flatten_reports(all_objects)
-            # remove any objects alread on the permission
+            # remove any objects already on the permission
             object_id_key = f"{data_type}_id"
             all_objects = [obj for obj in all_objects
                            if obj[object_id_key] not in perm_objects]

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -72,7 +72,7 @@ class AdminView(BaseView):
         """
         reports = [report.copy() for report in report_list]
         for report in reports:
-            report.update(report.get('report_parameters'))
+            report.update(report.pop('report_parameters'))
         return reports
 
     def get(self):
@@ -497,10 +497,9 @@ class PermissionView(AdminView):
             return render_template(
                 self.template, errors=e.errors, **self.template_args)
         if object_type == 'report':
-            object_map = self.flatten_reports(object_list)
-        else:
-            object_map = {obj[id_key]: obj
-                          for obj in object_list}
+            object_list = self.flatten_reports(object_list)
+        object_map = {obj[id_key]: obj
+                      for obj in object_list}
         # rebuild the 'objects' dict with the uuid: object structure
         # instead of uuid: created_at
         permission['objects'] = {
@@ -658,8 +657,7 @@ class PermissionObjectAddition(PermissionView):
 
             if data_type == 'report':
                 all_objects = api.list_metadata()
-                for rep in all_objects:
-                    rep.update(rep.pop('report_parameters'))
+                all_objects = self.flatten_reports(all_objects)
             else:
                 all_objects = api.list_metadata()
             all_objects = self.filter_by_org(all_objects, 'provider')

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -655,13 +655,14 @@ class PermissionObjectAddition(PermissionView):
             data_type = permission['object_type'][:-1]
             api = self.get_api_handler(permission['object_type'])
             perm_objects = list(permission['objects'].keys())
+
             if data_type == 'report':
                 all_objects = api.list_metadata()
-                all_objects = [rep.update(rep['report_parameters'])
-                               for rep in all_objects]
+                for rep in all_objects:
+                    rep.update(rep.pop('report_parameters'))
             else:
                 all_objects = api.list_metadata()
-                all_objects = self.filter_by_org(all_objects, 'provider')
+            all_objects = self.filter_by_org(all_objects, 'provider')
             # remove any objects alread on the permission
             object_id_key = f"{data_type}_id"
             all_objects = [obj for obj in all_objects
@@ -669,6 +670,7 @@ class PermissionObjectAddition(PermissionView):
             self.set_template_args(permission)
         return render_template(self.template,
                                table_data=all_objects,
+                               data_type=data_type,
                                **self.template_args,
                                **kwargs)
 

--- a/sfa_dash/templates/forms/admin/permission_macros.jinja
+++ b/sfa_dash/templates/forms/admin/permission_macros.jinja
@@ -1,4 +1,5 @@
 {% macro data_row(data_type, row_values, index, checked=false) %}
+{% autoescape true %}
 {% if data_type == 'observation' %}
   {% set uuid = row_values['observation_id'] %}
 {% elif data_type == 'forecast' %}
@@ -11,22 +12,28 @@
   <td>{{ row_values['name'] }}</td>
   <td>{{ row_values['variable'] | convert_varname }}</td>
   <td>{{ uuid }}</td>
-</tr> 
+</tr>
+{% endautoescape %}
 {% endmacro %}
 
 {% macro site_row(data_type, row_values, index, checked=false) %}
+{% autoescape true %}
 {% set uuid = row_values['site_id'] %}
 <tr visible="true">
   <td><input type="checkbox" name="objects-list-{{ index }}" value="{{ uuid }} {% if checked %}checked{% endif %}"></td>
   <td>{{ row_values['name'] }}</td>
   <td>{{ uuid }}</td>
 </tr>
+{% endautoescape %}
 {% endmacro %}
+
 {% macro report_row(data_type, row_values, index, checked=false) %}
+{% autoescape true %}
 {% set uuid = row_values['report_id'] %}
 <tr visible="true">
   <td><input type="checkbox" name="objects-list-{{ index }}" value="{{ uuid }}" {% if checked %}checked{% endif %}></td>
   <td>{{ row_values['name'] }}</td>
   <td>{{ uuid }}</td>
 </tr>
+{% endautoescape %}
 {% endmacro %}

--- a/sfa_dash/templates/forms/admin/permission_object_addition.html
+++ b/sfa_dash/templates/forms/admin/permission_object_addition.html
@@ -34,7 +34,7 @@
             <thead>
               <th class="selection-column" scope="col"></th>
               <th scope="col">Name</th>
-              {% if data_type in ['site', 'report'] %}
+              {% if data_type not in ['site', 'report'] %}
               <th scope="col">Variable</th>
               {% endif %}
               <th scope="col">UUID</th>
@@ -45,7 +45,7 @@
                   <i class="fa fa-warning"></i>
                   No Result
                 </td>
-              </tr> 
+              </tr>
               {% for i in range(table_data | length) %}
               {{ row_macro(data_type, table_data[i], i) }}
               {% endfor %}

--- a/sfa_dash/templates/forms/admin/role_macros.jinja
+++ b/sfa_dash/templates/forms/admin/role_macros.jinja
@@ -1,10 +1,12 @@
 {% macro data_row(row_values, index, checked=false) %}
 <tr visible="true">
+{% autoescape true %}
   <td><input type="checkbox" name="role-permission-{{ index }}" value="{{ row_values['permission_id'] }}" {% if checked %}checked{%endif%}></td>
   <td>{{ row_values['description'] }}</td>
   <td>{{ row_values['action']}}</td>
   <td>{{ row_values['object_type']}}</td>
   <td>{{ row_values['permission_id']}}</td>
-</tr> 
+{% endautoescape %}
+</tr>
 {% endmacro %}
 

--- a/sfa_dash/templates/forms/admin/role_permission_addition.html
+++ b/sfa_dash/templates/forms/admin/role_permission_addition.html
@@ -31,7 +31,7 @@
                 <i class="fa fa-warning"></i>
                 No Result
               </td>
-            </tr> 
+            </tr>
             {% for i in range(table_data | length) %}
               {% set row = table_data[i] %}
               {{ table_macros.data_row(row, i) }}

--- a/sfa_dash/templates/forms/admin/user_macros.jinja
+++ b/sfa_dash/templates/forms/admin/user_macros.jinja
@@ -1,8 +1,10 @@
 {% macro data_row(row_values, index) %}
+{% autoescape true %}
 <tr visible="true">
   <td><input type="checkbox" name="user-role-{{ index }}" value="{{ row_values['role_id'] }}"></td>
   <td>{{ row_values['name'] }}</td>
   <td>{{ row_values['description']}}</td>
-</tr> 
+</tr>
+{% endautoescape %}
 {% endmacro %}
 

--- a/sfa_dash/templates/forms/form_macros.jinja
+++ b/sfa_dash/templates/forms/form_macros.jinja
@@ -23,7 +23,7 @@
      name="{{ name }}"
      {% if name == 'name' %}{{ name_validation() }}{% endif %}
      {% if form_data is not none %}
-     value="{% autoescape true %}{{ form_data.get(name, default) }}{% endautoescape %}"
+     value="{{ form_data.get(name, default) | e}}"
      {% endif %}>
      {% if units is not none %}{{ units }}{% endif %}
   </div>

--- a/sfa_dash/templates/forms/form_macros.jinja
+++ b/sfa_dash/templates/forms/form_macros.jinja
@@ -17,7 +17,15 @@
   {% endif %}
   <label>{{ label }}</label><br/>
   <div class="input-wrapper">
-    <input type="{{ type }}" class="form-control {{ class }} {{ name }}-field" {{ extra_attr }}  name="{{ name }}"  {% if name == 'name' %}{{ name_validation() }}{% endif %} {% if form_data is not none %}value="{{ form_data.get(name, default) }}"{% endif %}>{% if units is not none %}{{ units }}{% endif %}
+    <input type="{{ type }}"
+     class="form-control {{ class }} {{ name }}-field"
+     {{ extra_attr }}
+     name="{{ name }}"
+     {% if name == 'name' %}{{ name_validation() }}{% endif %}
+     {% if form_data is not none %}
+     value="{% autoescape true %}{{ form_data.get(name, default) }}{% endautoescape %}"
+     {% endif %}>
+     {% if units is not none %}{{ units }}{% endif %}
   </div>
   {% if help_text is not none %}
   {{ help_button(name) }}
@@ -26,6 +34,7 @@
 {% endmacro %}
 
 {% macro select(label, name, options, default_value, help_text=None, required=False, form_data={}) %}
+{% autoescape true %}
   <label>{{ label }}</label>
   <div class="input-wrapper">
     <select class="form-control {{ name }}-field" name="{{ name }}"{% if required %} required {% endif %}>
@@ -38,6 +47,7 @@
   {{ help_button(name) }}
   <span class="help-text text-muted {{ name }}-help-text collapse">{{ help_text }}</span>
   {% endif %}
+{% endautoescape %}
 {% endmacro %}
 
 {% macro radio(label, name, options, help_text=None, required=False, form_data={}) %}


### PR DESCRIPTION
closes #326 
Also fixes an issue that occurred with unsafe permission descriptions being printed. Discovered that inside macros, global autoescape rules are not respected, so added explicit autoescape blocks to macros that print user provided data. We should also probably add the same user string validation to the description field at the API level.