### PR TITLE
Mesage flashing safety

### DIFF
--- a/sfa_dash/api_interface/util.py
+++ b/sfa_dash/api_interface/util.py
@@ -49,8 +49,8 @@ def handle_response(request_object):
             }
             if previous_page is not None and previous_page != request.url:
                 errors['404'] = errors['404'] + (
-                    f' <a href="{escape(previous_page)}">Return to the previous '
-                    'page.</a>')
+                    f' <a href="{escape(previous_page)}">Return to the '
+                    'previous page.</a>')
         elif request_object.status_code == 422:
             errors = request_object.json()['errors']
         if errors:

--- a/sfa_dash/api_interface/util.py
+++ b/sfa_dash/api_interface/util.py
@@ -1,4 +1,4 @@
-from flask import request
+from flask import request, escape
 
 from sfa_dash.errors import DataRequestException
 
@@ -49,7 +49,7 @@ def handle_response(request_object):
             }
             if previous_page is not None and previous_page != request.url:
                 errors['404'] = errors['404'] + (
-                    f' <a href="{previous_page}">Return to the previous '
+                    f' <a href="{escape(previous_page)}">Return to the previous '
                     'page.</a>')
         elif request_object.status_code == 422:
             errors = request_object.json()['errors']

--- a/sfa_dash/templates/sections/notifications.html
+++ b/sfa_dash/templates/sections/notifications.html
@@ -19,7 +19,7 @@
 	{% endfor %}
     {% endif %}
     {% for message in flashed_messages %}
-    <li class="alert alert-success">{{ message }}</li>
+    <li class="alert alert-success">{{ message | safe}}</li>
     {% endfor %}
   </ul>
 </div>
@@ -34,7 +34,7 @@
     {% endfor %}
     {% endif %}
     {% for warning in flashed_warnings %}
-    <li class="alert alert-warning">{{ warning }}</li>
+    <li class="alert alert-warning">{{ warning | safe }}</li>
     {% endfor %}
   </ul>
 </div>
@@ -49,7 +49,7 @@
     {% endfor %}
     {% endif %}
     {% for error in flashed_errors %}
-    <li class="alert alert-danger">{{ error }}</li>
+    <li class="alert alert-danger">{{ error | safe}}</li>
     {% endfor %}
   </ul>
 </div>

--- a/sfa_dash/tests/views/test_api_404.py
+++ b/sfa_dash/tests/views/test_api_404.py
@@ -169,6 +169,11 @@ def test_clone_routes(client, clone_route, missing_id):
     assert_contains_404(resp.data.decode('utf-8'))
 
 
+@pytest.fixture(params=['/sites/{missing_id}/', '/admin/users/{missing_id}'])
+def referer_test_route(request, missing_id):
+    return request.param.format(missing_id=missing_id)
+
+
 @pytest.mark.parametrize('referer,expected', [
     ('https://dashboard.solarforecastarbiter.org/sites/',
      '<a href="https://dashboard.solarforecastarbiter.org/sites/">'
@@ -179,8 +184,8 @@ def test_clone_routes(client, clone_route, missing_id):
      '?a=&#34;&gt;&lt;/a&gt;&lt;script&gt;console.log(&#34;test&#34;)&lt;'
      '/script&gt;&lt;a&gt;">Return to the previous page.</a>'),
 ])
-def test_previous_page_link(client, referer, expected, missing_id):
-    resp = client.get(f'/sites/{missing_id}/',
+def test_previous_page_link(client, referer, expected, referer_test_route):
+    resp = client.get(referer_test_route,
                       base_url=BASE_URL,
                       query_string={'site_id': dne_uuid},
                       headers={'Referer': referer})

--- a/sfa_dash/tests/views/test_api_404.py
+++ b/sfa_dash/tests/views/test_api_404.py
@@ -167,3 +167,22 @@ def test_clone_routes(client, clone_route, missing_id):
     resp = client.get(clone_route(ids), base_url=BASE_URL,
                       follow_redirects=True)
     assert_contains_404(resp.data.decode('utf-8'))
+
+
+@pytest.mark.parametrize('referer,expected', [
+    ('https://dashboard.solarforecastarbiter.org/sites/',
+     '<a href="https://dashboard.solarforecastarbiter.org/sites/">'
+     'Return to the previous page.</a>'),
+    ('https://dashboard.solarforecastarbiter.org/sites/'
+     '?a="></a><script>console.log("test")</script><a>',
+     '<a href="https://dashboard.solarforecastarbiter.org/sites/'
+     '?a=&#34;&gt;&lt;/a&gt;&lt;script&gt;console.log(&#34;test&#34;)&lt;'
+     '/script&gt;&lt;a&gt;">Return to the previous page.</a>'),
+])
+def test_previous_page_link(client, referer, expected, missing_id):
+    resp = client.get(f'/sites/{missing_id}/',
+                      base_url=BASE_URL,
+                      query_string={'site_id': dne_uuid},
+                      headers={'Referer': referer})
+    assert_contains_404(resp.data.decode('utf-8'))
+    assert expected in resp.data.decode('utf-8')


### PR DESCRIPTION
closes #328 
When printing messages via message flashing, messages weren't passed through the `safe` filter.  Also added a call to escape when inserting a link to the previous page to ensure we don't print anything dangerous found in the referrer header. 