### PR TITLE
Hide on create perm

### DIFF
--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -606,7 +606,7 @@ class PermissionsCreation(AdminView):
         """
         permission = {
             'description': form_data['description'],
-            'action': form_data['action'],
+            'action': form_data['permission-action'],
             'applies_to_all': ('applies-to-all' in form_data),
             'object_type': self.data_type + 's',
         }

--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -64,6 +64,17 @@ $(document).ready(function(){
         }
     });
     // hide interval_label = 'event' by default.
-    $('[name="interval_label"] option[value="event"]').prop(
-                'hidden', true);
+    $('[name="interval_label"] option[value="event"]').prop('hidden', true);
+
+    $('[name="permission-action"]').change(function(){
+        if (this.value == 'create'){
+            $('#non-create-permission-fields')
+                .prop('disabled', true)
+                .prop('hidden', true);
+        } else {
+            $('#non-create-permission-fields')
+                .prop('disabled', false)
+                .prop('hidden', false);
+        }
+    });
 });

--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -70,11 +70,17 @@ $(document).ready(function(){
         if (this.value == 'create'){
             $('#non-create-permission-fields')
                 .prop('disabled', true)
-                .prop('hidden', true);
+                .collapse('hide');
+            $('#create-permission-explanation')
+                .prop('hidden', false)
+                .collapse('show');
         } else {
             $('#non-create-permission-fields')
                 .prop('disabled', false)
-                .prop('hidden', false);
+                .collapse('show');
+            $('#create-permission-explanation')
+                .prop('hidden', true)
+                .collapse('hide');
         }
     });
 });

--- a/sfa_dash/templates/forms/admin/permission.html
+++ b/sfa_dash/templates/forms/admin/permission.html
@@ -55,4 +55,3 @@
 {% endif %}
 {% endif %}
 {% endblock %}
-

--- a/sfa_dash/templates/forms/admin/permission.html
+++ b/sfa_dash/templates/forms/admin/permission.html
@@ -5,14 +5,16 @@
 {% include 'data/metadata/permission_metadata.html' %}
 
 {% set update_allowed = is_allowed('update') %}
-{% if not permission['applies_to_all'] and update_allowed %}
+{% if not permission['applies_to_all']
+   and update_allowed
+   and permission['action'] != 'create'%}
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('admin.permission_object_addition', uuid=permission['permission_id']) }}">Add Objects to Permission</a>
 {% endif %}
 
 {% if is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('admin.delete_permission', uuid=permission['permission_id']) }}">Delete</a>
 {% endif %}
-
+{% if permission['action'] != 'create' %}
 <h3 class="my-3">{{ permission['object_type'] | title }}</h3>
 <div class="tools {{ table_type }}-tools mt-1">
    {% block tools %}
@@ -51,4 +53,6 @@
   </tbody>
 </table>
 {% endif %}
+{% endif %}
 {% endblock %}
+

--- a/sfa_dash/templates/forms/admin/permissions_form.html
+++ b/sfa_dash/templates/forms/admin/permissions_form.html
@@ -29,7 +29,7 @@
   <p>Select the action this permission will allow.</p>
   <input type="radio" name="permission-action" value="create" required>Create
   <input type="radio" name="permission-action" value="read">Read
-  {% if data_type not in ['fpermission-orecast', 'observation', 'site'] %}
+  {% if data_type not in ['forecast', 'observation', 'site'] %}
   <input type="radio" name="permission-action" value="update">Update
   {% endif %}
   <input type="radio" name="permission-action" value="delete">Delete

--- a/sfa_dash/templates/forms/admin/permissions_form.html
+++ b/sfa_dash/templates/forms/admin/permissions_form.html
@@ -39,7 +39,13 @@
   <input type="radio" name="permission-action" value="delete_values">Delete Values
   {% endif %}
 </div>
-<fieldset id="non-create-permission-fields">
+<div id="create-permission-explanation" class="collapse">
+<p>Create permissions don't require any further configuration, but creating new
+metadata may require other permissions. For example, creating an Observation at
+a Site requires <i>Create</i> permissions for Observations and <i>Read</i>
+permission on the Site.</p>
+</div>
+<fieldset id="non-create-permission-fields" class="collapse show">
 <div class="form-element full-width">
   <label>Applies to all</label>
   <input type="checkbox" name="applies-to-all" data-toggle="collapse" data-target="#object-selector">

--- a/sfa_dash/templates/forms/admin/permissions_form.html
+++ b/sfa_dash/templates/forms/admin/permissions_form.html
@@ -44,7 +44,7 @@
     'site': '',
     'observation': '<i>Read</i> permissions on the associated Site',
     'forecast': '<i>Read</i> permissions on the associated Site',
-    'aggregate': '<i>Read</i> and <i>Read Values</i> permissions on Observations to make up the aggregate',
+    'aggregate': '<i>Read</i> and <i>Read Values</i> permissions on Observations that make up the Aggregate',
     'cdf_forecast_group': '<i>Read</i> permissions on the associated Site',
     'report': '<i>Read</i> and <i>Read Values</i> permissions on any Forecasts or Observations you would like to analyze in the Report',
 } %}

--- a/sfa_dash/templates/forms/admin/permissions_form.html
+++ b/sfa_dash/templates/forms/admin/permissions_form.html
@@ -27,18 +27,19 @@
 <div class="form-element full-width">
   <label>Action</label><br/>
   <p>Select the action this permission will allow.</p>
-  <input type="radio" name="action" value="create" required>Create
-  <input type="radio" name="action" value="read">Read
-  {% if data_type not in ['forecast', 'observation', 'site'] %}
-  <input type="radio" name="action" value="update">Update 
+  <input type="radio" name="permission-action" value="create" required>Create
+  <input type="radio" name="permission-action" value="read">Read
+  {% if data_type not in ['fpermission-orecast', 'observation', 'site'] %}
+  <input type="radio" name="permission-action" value="update">Update
   {% endif %}
-  <input type="radio" name="action" value="delete">Delete
+  <input type="radio" name="permission-action" value="delete">Delete
   {% if data_type != "site" %}
-  <input type="radio" name="action" value="read_values">Read Values
-  <input type="radio" name="action" value="write_values">Write Values
-  <input type="radio" name="action" value="delete_values">Delete Values
+  <input type="radio" name="permission-action" value="read_values">Read Values
+  <input type="radio" name="permission-action" value="write_values">Write Values
+  <input type="radio" name="permission-action" value="delete_values">Delete Values
   {% endif %}
 </div>
+<fieldset id="non-create-permission-fields">
 <div class="form-element full-width">
   <label>Applies to all</label>
   <input type="checkbox" name="applies-to-all" data-toggle="collapse" data-target="#object-selector">
@@ -69,7 +70,7 @@
               <i class="fa fa-warning"></i>
               No Result
             </td>
-          </tr> 
+          </tr>
           {% for i in range(table_data | length) %}
           {{ row_macro(data_type, table_data[i], i, "objects-list" + i |string in form_data ) }}
           {% endfor %}
@@ -78,4 +79,5 @@
     </div>
   </div>
 </div>
+</fieldset>
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/permissions_form.html
+++ b/sfa_dash/templates/forms/admin/permissions_form.html
@@ -40,10 +40,18 @@
   {% endif %}
 </div>
 <div id="create-permission-explanation" class="collapse">
-<p>Create permissions don't require any further configuration, but creating new
-metadata may require other permissions. For example, creating an Observation at
-a Site requires <i>Create</i> permissions for Observations and <i>Read</i>
-permission on the Site.</p>
+{% set perm_requirements = {
+    'site': '',
+    'observation': '<i>Read</i> permissions on the associated Site',
+    'forecast': '<i>Read</i> permissions on the associated Site',
+    'aggregate': '<i>Read</i> and <i>Read Values</i> permissions on Observations to make up the aggregate',
+    'cdf_forecast_group': '<i>Read</i> permissions on the associated Site',
+    'report': '<i>Read</i> and <i>Read Values</i> permissions on any Forecasts or Observations you would like to analyze in the Report',
+} %}
+<p>Create permissions don't require any further configuration
+{% if perm_requirements.get(data_type, '') | length %} but creating new
+{{ data_type | convert_data_type }}s requires {{ perm_requirements[data_type] | safe }}
+{% endif %}.</p>
 </div>
 <fieldset id="non-create-permission-fields" class="collapse show">
 <div class="form-element full-width">


### PR DESCRIPTION
closes #337 

- Added a description section to explain why we're hiding the "applies to all" option and the listing when a user is creating a permission with create action. When the user selects 'create' the section expands, and the 'applies to all' and listing collapses. The opposite occurs when the user selects a different action.  Here's what I have for the description: 

> Create permissions don't require any further configuration, but creating new metadata may require other permissions. For example, creating an Observation at a Site requires Create permissions for Observations and Read permission on the Site.

- Hid the "Add objects to this permission" button, and the table of objects on permission pages when the action of that permission is 'create'.
