### PR TITLE
Limit variable options when site does not have modeling params

### DIFF
--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -16,6 +16,10 @@ data_type_mapping = {
     'aggregate': 'Aggregate',
 }
 
+# variables that require a site has modeling parameters
+MODELING_PARAM_VARIABLES = ['ac_power', 'dc_power', 'poa_global',
+                            'curtailment', 'availability']
+
 
 def api_to_dash_varname(api_varname):
     return COMMON_NAMES[api_varname]
@@ -90,6 +94,18 @@ def climate_zone_links(zones):
         return ["No Climate Zone"]
 
 
+def site_variable_options(site_metadata):
+    has_modeling_parameters = any(
+        site_metadata['modeling_parameters'].values())
+    variable_options = {key: f'{value} ({api_varname_to_units(key)})'
+                        for key, value in variable_mapping.items()}
+    if has_modeling_parameters:
+        return variable_options
+    else:
+        return {k: v for k, v in variable_options.items()
+                if k not in MODELING_PARAM_VARIABLES}
+
+
 def register_jinja_filters(app):
     app.jinja_env.filters['convert_varname'] = api_to_dash_varname
     app.jinja_env.filters['var_to_units'] = api_varname_to_units
@@ -98,3 +114,4 @@ def register_jinja_filters(app):
     app.jinja_env.filters['format_datetime'] = format_datetime
     app.jinja_env.filters['is_number'] = is_number
     app.jinja_env.filters['climate_zone_links'] = climate_zone_links
+    app.jinja_env.filters['site_variable_options'] = site_variable_options

--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -18,7 +18,7 @@ data_type_mapping = {
 
 # variables that require a site has modeling parameters
 MODELING_PARAM_VARIABLES = ['ac_power', 'dc_power', 'poa_global',
-                            'curtailment', 'availability']
+                            'availability']
 
 
 def api_to_dash_varname(api_varname):

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -33,9 +33,6 @@ DEFAULT_METRICS = ['mae', 'mbe', 'rmse']
 
 DEFAULT_CATEGORIES = ['total', 'year', 'month', 'hour', 'date']
 
-MODELING_PARAM_VARIABLES = ['ac_power', 'dc_power', 'poa_global',
-                            'curtailment', 'availability']
-
 ALL_METRICS = {}
 ALL_METRICS.update(ALLOWED_DETERMINISTIC_METRICS)
 ALL_METRICS.update(ALLOWED_EVENT_METRICS)

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -33,6 +33,9 @@ DEFAULT_METRICS = ['mae', 'mbe', 'rmse']
 
 DEFAULT_CATEGORIES = ['total', 'year', 'month', 'hour', 'date']
 
+MODELING_PARAM_VARIABLES = ['ac_power', 'dc_power', 'poa_global',
+                            'curtailment', 'availability']
+
 ALL_METRICS = {}
 ALL_METRICS.update(ALLOWED_DETERMINISTIC_METRICS)
 ALL_METRICS.update(ALLOWED_EVENT_METRICS)

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -15,7 +15,7 @@
 {% if site_metadata is defined %}
 <div class="form-element">
   {{ form.select('Variable', 'variable',
-                 variable_options,
+                 site_metadata | site_variable_options,
                  default_variable,
                  form_data=form_data) }}
 </div>

--- a/sfa_dash/templates/forms/forecast_form.html
+++ b/sfa_dash/templates/forms/forecast_form.html
@@ -13,9 +13,10 @@
 {# If a site is defined, allow the user to select a variable, otherwise fetch
    the variable from the aggregate #}
 {% if site_metadata is defined %}
+
 <div class="form-element">
   {{ form.select('Variable', 'variable',
-                 variable_options,
+                 site_metadata | site_variable_options,
                  default_variable,
                  form_data=form_data) }}
 </div>

--- a/sfa_dash/templates/forms/observation_form.html
+++ b/sfa_dash/templates/forms/observation_form.html
@@ -12,7 +12,7 @@
 </div>
 <div class="form-element">
   {{ form.select('Variable', 'variable',
-                 variable_options,
+                 site_metadata | site_variable_options,
                  default_variable,
                  form_data=form_data) }}
 </div>

--- a/sfa_dash/templates/forms/site_form.html
+++ b/sfa_dash/templates/forms/site_form.html
@@ -36,9 +36,10 @@
   <input type="radio" name="site_type" data-toggle="collapse" data-target=".pv-model-params:not(.show)" value="power-plant" class="site_type-field"{% if site_type == 'power-plant' %} checked{% endif %}/>Power Plant
   {{ form.help_button('site_type') }}
   <span class="site_type-help-text form-text text-muted help-text collapse" aria-hidden>
-      Power plants will require pv system modeling parameters and will allow
-      for power forecasts and observations (AC power, DC power, plane of array
-      irradiance, and availability).
+     Choose Weather Station if the Site will only be used for observations and
+     forecasts of irradiance and other weather variables. Choose Power Plant to
+     specify PV system modeling parameters and enable observations and
+     forecasts of power.
   </span>
 </div>
 <div class="pv-model-params collapse {% if site_type == 'power-plant' %}show{% endif %}">

--- a/sfa_dash/templates/forms/site_form.html
+++ b/sfa_dash/templates/forms/site_form.html
@@ -34,6 +34,12 @@
   {% set site_type = form_data.get('site_type', None) %}
   <input type="radio" name="site_type" data-toggle="collapse" data-target=".pv-model-params.show" value="weather-station" class="site_type-field"{% if site_type == 'weather-station' or site_type is none %} checked {% endif %}/>Weather Station
   <input type="radio" name="site_type" data-toggle="collapse" data-target=".pv-model-params:not(.show)" value="power-plant" class="site_type-field"{% if site_type == 'power-plant' %} checked{% endif %}/>Power Plant
+  {{ form.help_button('site_type') }}
+  <span class="site_type-help-text form-text text-muted help-text collapse" aria-hidden>
+      Power plants will require pv system modeling parameters and will allow
+      for power forecasts and observations (AC power, DC power, plane of array
+      irradiance, and availability).
+  </span>
 </div>
 <div class="pv-model-params collapse {% if site_type == 'power-plant' %}show{% endif %}">
   <fieldset name="modeling_parameters">


### PR DESCRIPTION
closes #338 
Adds a filter that takes a dict of site metadata, and returns a list of variable options to present in forecast and observation forms. If the site does not contain any modeling parameters, it removes power variables. 