### PR TITLE
Conditional action display

### DIFF
--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -89,10 +89,10 @@ def create_app(config=None):
                 # cdf_forecast_single, where permissions are dependent on
                 # the parent cdf_forecast_group
                 pass
-            try:
-                g.can_create = users.get_create_permissions()['can_create']
-            except DataRequestException:
-                pass
+        try:
+            g.can_create = users.get_create_permissions()['can_create']
+        except DataRequestException:
+            pass
         global_template_args.update(template_variables())
         return global_template_args
 

--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -89,6 +89,10 @@ def create_app(config=None):
                 # cdf_forecast_single, where permissions are dependent on
                 # the parent cdf_forecast_group
                 pass
+            try:
+                g.can_create = users.get_create_permissions()['can_create']
+            except DataRequestException:
+                pass
         global_template_args.update(template_variables())
         return global_template_args
 

--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -79,20 +79,22 @@ def create_app(config=None):
     def inject_globals():
         # Injects variables into all rendered templates
         global_template_args = {}
-        global_template_args['current_user'] = session.get('userinfo')
-        if 'uuid' in request.view_args:
-            uuid = request.view_args.get('uuid')
+        current_user = session.get('userinfo')
+        global_template_args['current_user'] = current_user
+        if current_user is not None:
+            if 'uuid' in request.view_args:
+                uuid = request.view_args.get('uuid')
+                try:
+                    g.allowed_actions = users.actions_on(uuid)['actions']
+                except DataRequestException:
+                    # Allow for special cases to later set g.allowed_actions
+                    # e.g. cdf_forecast_single, where permissions are dependent
+                    # on the parent cdf_forecast_group
+                    pass
             try:
-                g.allowed_actions = users.actions_on(uuid)['actions']
-            except DataRequestException:
-                # Allow for special cases to later set g.allowed_actions e.g.
-                # cdf_forecast_single, where permissions are dependent on
-                # the parent cdf_forecast_group
+                g.can_create = users.get_create_permissions()['can_create']
+            except (DataRequestException):
                 pass
-        try:
-            g.can_create = users.get_create_permissions()['can_create']
-        except DataRequestException:
-            pass
         global_template_args.update(template_variables())
         return global_template_args
 

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -53,7 +53,19 @@ def actions_on(uuid):
 
 
 def actions_on_type(object_type):
-    """Returns a dictionary of `{uuid: actions, ..}`."""
+    """Get a list of objects and actions user can perform on them.
+
+    Parameters
+    ----------
+    object_type: str
+        The type of object to query for. Note that the api uses plural type
+        notation, e.g. `observations`.
+    Returns
+    -------
+    dict
+        Dictionary where keys are object uuids and values are a list of
+        permitted actions.
+    """
     req = get_request(f'/users/actions-on-type/{object_type}')
     actions_dict = {obj['object_id']: obj['actions'] for obj in req['objects']}
     return actions_dict

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -53,8 +53,10 @@ def actions_on(uuid):
 
 
 def actions_on_type(object_type):
+    """Returns a dictionary of `{uuid: actions, ..}`."""
     req = get_request(f'/users/actions-on-type/{object_type}')
-    return req
+    actions_dict = {obj['object_id']: obj['actions'] for obj in req['objects']}
+    return actions_dict
 
 
 def get_create_permissions():

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -50,3 +50,13 @@ def get_email(user_id):
 def actions_on(uuid):
     req = get_request(f'/users/actions-on/{uuid}')
     return req
+
+
+def actions_on_type(object_type):
+    req = get_request(f'/users/actions-on-type/{object_type}')
+    return req
+
+
+def get_create_permissions():
+    req = get_request('/users/can-create/')
+    return req

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -137,7 +137,9 @@ class UserRoleAddition(AdminView):
                            for role_id, actions in role_permissions.items()
                            if 'grant' in actions]
 
-        # remove any roles the grantee already has or grantor cannot be granted
+        # Remove any roles the grantee already has or grantor cannot grant.
+        # Note that no user should have grant priveleges on a role belonging to
+        # another organization, as this is disallowed at the API.
         all_roles = [role for role in all_roles
                      if role['role_id'] not in user_roles
                      and role['role_id'] in grantable_roles]

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -2,7 +2,7 @@ from flask import (request, redirect, url_for, render_template, send_file,
                    current_app, flash)
 
 from sfa_dash.api_interface import (observations, forecasts, sites, reports,
-                                    aggregates, cdf_forecast_groups)
+                                    aggregates, cdf_forecast_groups, users)
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.errors import DataRequestException
 from sfa_dash.form_utils import converters
@@ -24,6 +24,13 @@ class ReportsView(BaseView):
             reports_list = reports.list_metadata()
         except DataRequestException as e:
             return {'errors': e.errors}
+        try:
+            all_actions = users.actions_on_type('reports')
+        except DataRequestException:
+            all_actions = {}
+        for report in reports_list:
+            report.update(
+                {'actions': all_actions.get(report['report_id'], [])})
         self.template_args = {
             "page_title": 'Reports',
             "reports": reports_list,

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -75,6 +75,24 @@ def is_allowed(action):
     return action in allowed
 
 
+def can_create(object_type):
+    """Returns if a user can create an object type or not
+
+    Parameters
+    ----------
+    object_type: str
+        Type of object to check for create permissions. Should use the plural
+        e.g. observations.
+
+    Returns
+    -------
+    bool
+        True if the user can create the object type, else false.
+    """
+    allowed = object_type in getattr(g, 'can_create', [])
+    return allowed
+
+
 def template_variables():
     return {
         'dashboard_version': sfa_dash.__version__,
@@ -96,4 +114,5 @@ def template_variables():
         'variable_names': COMMON_NAMES,
         'variable_unit_map': ALLOWED_VARIABLES,
         'interval_label_options': INTERVAL_LABEL_OPTIONS,
+        'can_create': can_create,
     }

--- a/sfa_dash/templates/data/aggregate.html
+++ b/sfa_dash/templates/data/aggregate.html
@@ -8,9 +8,12 @@
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.add_aggregate_observations', uuid=metadata['aggregate_id'] ) }}">Add Observation</a>
 {% endif %}
 
+{% if can_create('forecasts') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_aggregate_forecast', uuid=metadata['aggregate_id'] ) }}">Create Forecast</a>
-
+{% endif %}
+{% if can_create('cdf_forecasts') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_aggregate_cdf_forecast_group', uuid=metadata['aggregate_id'] ) }}">Create Probabilistic Forecast</a>
+{% endif %}
 
 {% if is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_aggregate', uuid=metadata['aggregate_id']) }}">Delete</a>

--- a/sfa_dash/templates/data/aggregates.html
+++ b/sfa_dash/templates/data/aggregates.html
@@ -2,8 +2,10 @@
 {% block content %}
 <div class="tools {{ table_type }}-tools mt-1">
   <input type="text" placeholder="Search" class="search">
+  {% if can_create('aggregates') %}
   <a role="button" class="btn btn-primary btn-sm" href="/aggregates/create">Create new Aggregate</a>
-</div> 
+  {% endif %}
+</div>
 {% include "sections/notifications.html" %}
 <table class="aggregates-table table results">
   <thead>
@@ -15,7 +17,7 @@
   </thead>
   <tbody>
     <tr class="warning no-result">
-      <td colspan="4"><i class="fa fa-warning"></i>No result</td> 
+      <td colspan="4"><i class="fa fa-warning"></i>No result</td>
     </tr>
   {% for agg in aggregates %}
     <tr class="aggregates-table-row">

--- a/sfa_dash/templates/data/intermediate_report.html
+++ b/sfa_dash/templates/data/intermediate_report.html
@@ -8,7 +8,7 @@
 <h1 id="report-title">{{ report['report_parameters']['name'] }}</h1>
 {% endif %}
 {% if is_allowed('update') %}<a class="btn btn-primary btn-sm" href="{{url_for('forms.recompute_report', uuid=report['report_id'])}}">Recompute report</a>{% endif %}
-{% if is_allowed('read') %}<a class="btn btn-primary btn-sm" href="{{url_for('forms.clone_report', uuid=report['report_id'])}}">Clone report parameters</a>{% endif %}
+{% if is_allowed('read') and can_create('reports') %}<a class="btn btn-primary btn-sm" href="{{url_for('forms.clone_report', uuid=report['report_id'])}}">Clone report parameters</a>{% endif %}
 </div>
 {% endblock %}
 {% block download %}

--- a/sfa_dash/templates/data/reports.html
+++ b/sfa_dash/templates/data/reports.html
@@ -3,7 +3,9 @@
 {% block content %}
 <div class="tools {{ table_type }}-tools mt-1">
   <input type="text" placeholder="Search" class="search">
+  {% if can_create('reports') %}
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_deterministic_report')}}">Create new Report</a>
+  {% endif %}
 </div>
 
 {% include "sections/notifications.html" %}

--- a/sfa_dash/templates/data/reports.html
+++ b/sfa_dash/templates/data/reports.html
@@ -76,7 +76,10 @@
             <a role="button" class="report-details-closer">close</a>
             </div>
             {# end report metadata block #}
-        <td><a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_report', uuid=report['report_id']) }}">Delete</a>
+        <td>
+            {% if 'delete' in report['actions'] %}
+            <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_report', uuid=report['report_id']) }}">Delete</a>
+            {% endif %}
         <td class="reports-table-status-column">{{ report['status'] }}</td>
     </tr>
   {% endfor %}

--- a/sfa_dash/templates/data/reports.html
+++ b/sfa_dash/templates/data/reports.html
@@ -80,6 +80,7 @@
             {% if 'delete' in report['actions'] %}
             <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_report', uuid=report['report_id']) }}">Delete</a>
             {% endif %}
+        </td>
         <td class="reports-table-status-column">{{ report['status'] }}</td>
     </tr>
   {% endfor %}

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -2,9 +2,15 @@
 {% block content %}
 {% if metadata is defined %}
 {% block toolbar %}
+{% if can_create('observations') %}
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_observation', uuid=site_id) }}">Create new Observation</a>
+{% endif %}
+{% if can_create('forecasts') %}
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_forecast', uuid=site_id) }}">Create new Forecast</a>
+{% endif %}
+{% if can_create('cdf_forecasts') %}
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast_group', uuid=site_id) }}">Create new Probabilistic Forecast</a>
+{% endif %}
   {% if is_allowed('delete') %}
   <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_site', uuid=site_id) }}">Delete this site</a>
   {% endif %}

--- a/sfa_dash/templates/data/table/cdf_forecast_table.html
+++ b/sfa_dash/templates/data/table/cdf_forecast_table.html
@@ -1,6 +1,6 @@
 <div class="tools forecast-tools mt-1">
 <input type="text" placeholder="Search" class="search">
-{% if creation_link is not none %}
+{% if creation_link is not none and can_create('cdf_forecasts') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ creation_link }}">Create new Probabilistic Forecast</a>
 {% endif %}
 </div>

--- a/sfa_dash/templates/data/table/forecast_table.html
+++ b/sfa_dash/templates/data/table/forecast_table.html
@@ -1,6 +1,6 @@
 <div class="tools forecast-tools mt-1">
 <input type="text" placeholder="Search" class="search">
-{% if creation_link is not none %}
+{% if creation_link is not none and can_create('forecasts') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ creation_link }}">Create new Forecast</a>
 {% endif %}
 </div>

--- a/sfa_dash/templates/data/table/observation_table.html
+++ b/sfa_dash/templates/data/table/observation_table.html
@@ -1,6 +1,6 @@
 <div class="tools observation-tools mt-1">
 <input type="text" placeholder="Search" class="search">
-{% if creation_link is not none %}
+{% if creation_link is not none and can_create('observations') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ creation_link }}">Create new Observation</a>
 {% endif %}
 </div>

--- a/sfa_dash/templates/data/table/site_table.html
+++ b/sfa_dash/templates/data/table/site_table.html
@@ -1,6 +1,6 @@
 <div class="tools site-tools mt-1">
   <input type="text" placeholder="Search" class="search">
-  {% if creation_link is defined and creation_link is not none %}
+  {% if creation_link is defined and creation_link is not none and can_create('sites') %}
     <a role="button" class="btn btn-primary btn-sm" href="{{ creation_link }}">Create new Site</a>
   {% endif %}
 </div>

--- a/sfa_dash/templates/forms/admin/permissions.html
+++ b/sfa_dash/templates/forms/admin/permissions.html
@@ -1,6 +1,7 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'Permissions' %}
 {% block content %}
+{% if can_create('permissions') %}
 <div class="data-metadata border mt-2">
   <h3>Create a New Permission</h3>
   Select a data type:
@@ -10,9 +11,8 @@
   <a class="btn-sm btn-primary" href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecasts</a>
   <a class="btn-sm btn-primary" href='{{ url_for("admin.report_permission") }}'>Reports</a>
   <a class="btn-sm btn-primary" href='{{ url_for("admin.aggregate_permission") }}'>Aggregates</a>
-
-
 </div>
+{% endif %}
 <h3 class="my-3">Existing Permissions</h3>
 <div class="tools {{ table_type }}-tools mt-1">
   {% block tools %}

--- a/sfa_dash/templates/forms/admin/permissions.html
+++ b/sfa_dash/templates/forms/admin/permissions.html
@@ -41,7 +41,7 @@
             <td class="action-column">{{ perm["action"] }}</td>
             <td class="object-type-column">{{ perm["object_type"] }} </td>
 
-            <td class="applies-to-all-column">{% if perm["applies_to_all"] %}&#10004;{% endif %} </td>
+            <td class="applies-to-all-column">{% if perm["applies_to_all"] %}&#10004;{% else %}&#10060;{% endif %} </td>
         </tr>
       {% endfor %}
     {% endif %}

--- a/sfa_dash/templates/forms/admin/roles.html
+++ b/sfa_dash/templates/forms/admin/roles.html
@@ -6,7 +6,9 @@
   {% block tools %}
     <input type="text" placeholder="Search" class="search">
   {% endblock %}
+  {% if can_create('roles') %}
   <a role="button" class="btn btn-primary" href="{{ url_for('admin.create_role') }}">Create new Role</a>
+  {% endif %}
 </div>
 <table class="roles-table table results">
   <thead>


### PR DESCRIPTION
Uses endpoints introduced in https://github.com/SolarArbiter/solarforecastarbiter-api/pull/272 to:
- hide `create X` buttons when user does not have create permission
- remove delete buttons from the report listing when the user cannot delete that report
- remove roles that the user cannot grant from the 'Add Roles to User' form. 

closes #344 
closes #212