### PR TITLE
Reference forecast inclusion options

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -408,8 +408,8 @@ a:not([href]).collapser-button:hover{
     color: #0056b3;
 }
 .collapser-button::after{
-    width: 0; 
-    height: 0; 
+    width: 0;
+    height: 0;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
     border-bottom: 5px solid #007bff;
@@ -423,6 +423,10 @@ a:not([href]).collapser-button:hover{
 }
 .report-field-filters{
     display: inline-block;
+    margin-bottom: .5em;
+}
+.report-field-filters .form-control{
+    margin-left: 0;
 }
 ul.pair-constant-values{
     padding-left: 2em;

--- a/sfa_dash/static/js/event-report-form-handling.js
+++ b/sfa_dash/static/js/event-report-form-handling.js
@@ -24,30 +24,33 @@ function addPair(
      *  @param {string} forecast_type
      *      The type of forecast in the pair. Defaults to 'event_forecast'.
      */
-    var new_object_pair = $(`<div class="object-pair pair-container object-pair-${pair_index}">
-            <div class="input-wrapper">
-              <div class="col-md-12">
-                <div class="object-pair-label forecast-name-${pair_index}"><b>Forecast: </b>${fx_name}</div>
-                <input type="hidden" class="form-control forecast-value" name="forecast-id-${pair_index}" required value="${fx_id}"/>
-                <div class="object-pair-label truth-name-${pair_index}"><b>Observation: </b> ${truth_name}</div>
-                <input type="hidden" class="form-control truth-value" name="truth-id-${pair_index}" required value="${truth_id}"/>
-                <input type="hidden" class="form-control truth-type-value" name="truth-type-${pair_index}" required value="${truth_type}"/>
-                <input type="hidden" class="form-control deadband-value" name="deadband-value-${pair_index}" required value="null"/>
-                <input type="hidden" class="form-control reference-forecast-value" name="reference-forecast-${pair_index}" required value="null"/>
-                <input type="hidden" class="forecast-type-value" name="forecast-type-${pair_index}" required value="${forecast_type}"/>
-              </div>
-             </div>
-             <a role="button" class="object-pair-delete-button">remove</a>
-           </div>`);
-    var remove_button = new_object_pair.find(".object-pair-delete-button");
-    remove_button.click(function(){
-        new_object_pair.remove();
-        if ($('.object-pair-list .object-pair').length == 0){
-            $('.empty-reports-list')[0].hidden = false;
-        }
-    });
-    pair_container.append(new_object_pair);
-    pair_index++;
+    if (report_utils.try_insert_pair(fx_id, truth_id, null, null, null)){
+        var new_object_pair = $(`<div class="object-pair pair-container object-pair-${pair_index}">
+                <div class="input-wrapper">
+                  <div class="col-md-12">
+                    <div class="object-pair-label forecast-name-${pair_index}"><b>Forecast: </b>${fx_name}</div>
+                    <input type="hidden" class="form-control forecast-value" name="forecast-id-${pair_index}" required value="${fx_id}"/>
+                    <div class="object-pair-label truth-name-${pair_index}"><b>Observation: </b> ${truth_name}</div>
+                    <input type="hidden" class="form-control truth-value" name="truth-id-${pair_index}" required value="${truth_id}"/>
+                    <input type="hidden" class="form-control truth-type-value" name="truth-type-${pair_index}" required value="${truth_type}"/>
+                    <input type="hidden" class="form-control deadband-value" name="deadband-value-${pair_index}" required value="null"/>
+                    <input type="hidden" class="form-control reference-forecast-value" name="reference-forecast-${pair_index}" required value="null"/>
+                    <input type="hidden" class="forecast-type-value" name="forecast-type-${pair_index}" required value="${forecast_type}"/>
+                  </div>
+                 </div>
+                 <a role="button" class="object-pair-delete-button">remove</a>
+               </div>`);
+        var remove_button = new_object_pair.find(".object-pair-delete-button");
+        remove_button.click(function(){
+            new_object_pair.remove();
+            report_utils.remove_pair(fx_id, truth_id, null, null, null);
+            if ($('.object-pair-list .object-pair').length == 0){
+                $('.empty-reports-list')[0].hidden = false;
+            }
+        });
+        pair_container.append(new_object_pair);
+        pair_index++;
+    }
 }
 
 function createPairSelector(){

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -323,27 +323,6 @@ function newConstantValueSelector(){
           </div>`);
 }
 
-function newSelector(field_name, depends_on=null, required=true, description="",classes=[]){
-    /*
-     * Returns a JQuery object containing labels and select elements for appending options to.
-     * Initializes with one default and one optional select option:
-     *     Always adds an option containing "No matching <field_Type>s
-     *     If depends_on is provided, inserts a "Please select a <depends_on> option>
-     */
-    var field_type = field_name.toLowerCase().replace(/ /g, '-');
-    return $(`<div class="form-element full-width ${field_type}-select-wrapper">
-                <label>Select a ${field_name} ${required ? "" : "(Optional)"}</label>
-                  <div class="report-field-filters"><input id="${field_type}-option-search" class="form-control half-width" placeholder="Search by ${field_name} name"/></div><br>
-                <div class="selector-description">${description}</div>
-                <div class="input-wrapper">
-                  <select id="${field_type}-select" class="form-control ${field_type}-field ${classes.join(" ")}" name="${field_type}-select" size="5">
-                  ${depends_on ? `<option id="no-${field_type}-${depends_on}-selection" disabled> Please select a ${depends_on}.</option>` : ""}
-                  <option id="no-${field_type}s" disabled hidden>No matching ${field_name}s</option>
-                </select>
-                </div>
-              </div>`);
-}
-
 function createPairSelector(){
     /*
      * Returns a JQuery object containing Forecast, Observation pair widgets to insert into the DOM
@@ -570,10 +549,10 @@ function createPairSelector(){
      * Create the control elements for creating observation, forecast pairs
      *
      *********************************************************************/
-    var siteSelector = newSelector("site");
-    var aggregateSelector = newSelector("aggregate", "distribution",);
-    var obsSelector = newSelector("observation", "distribution");
-    var fxSelector = newSelector(
+    var siteSelector = report_utils.newSelector("site");
+    var aggregateSelector = report_utils.newSelector("aggregate", "distribution",);
+    var obsSelector = report_utils.newSelector("observation", "distribution");
+    var fxSelector = report_utils.newSelector(
         "distribution", "site", required=true,
         description=`
             The Solar Forecast Arbiter supports the specification of
@@ -587,7 +566,7 @@ function createPairSelector(){
             for each forecast.`
     );
 
-    var refFxSelector = newSelector(
+    var refFxSelector = report_utils.newSelector(
         "reference forecast", "forecast", required=false,
         description='Skill metrics will be calculated for any binary forecasts matching the selection above.');
     refFxSelector.find('label').after(report_utils.reference_inclusion_button);

--- a/sfa_dash/static/js/probabilistic-report-form-handling.js
+++ b/sfa_dash/static/js/probabilistic-report-form-handling.js
@@ -105,62 +105,65 @@ function addPair(
      *      probabilistic forecast groups, this is just the forecast_id. For
      *      probabilistic forecast constant values, this is the parent field.
      */
-    var new_container = false;
+    if (report_utils.try_insert_pair(fx_id, truth_id, ref_fx_id, db_label, db_value)){
+        var new_container = false;
 
-    if (forecast_type=='probabilistic_forecast'){
-        $('[name="metrics"][value="crps"]').attr('checked', true);
-    }
-
-    // Check for the parent pair container that groups object_pairs
-    // with similar observations, forecasts and uncertainties
-    var pair_container = $(`
-        .pair-container[data-truth-id=${truth_id}][data-fx-id=${distribution_id}][data-deadband-value="${db_value}"]`);
-    if (pair_container.length == 0){
-        pair_container = pairWrapper(
-            truth_type, truth_id, truth_name, fx_id, fx_name, ref_fx_name,
-            db_label, db_value, distribution_id);
-        new_container = true;
-    }
-
-    // Get a handle to the list where we will append constant value pairs
-    var constant_values = pair_container.find('.pair-constant-values');
-
-    var constant_value_pair = $(`<li class="object-pair object-pair-${pair_index}">
-        <div class="constant-value-label">${constant_value}</div>
-        <div class="object-pair-label reference-forecast-name"><b>Reference Forecast: </b> ${ref_fx_name}</div>
-        <input type="hidden" class="forecast-value" name="forecast-id-${pair_index}" required value="${fx_id}"/>
-        <input type="hidden" class="truth-value" name="truth-id-${pair_index}" required value="${truth_id}"/>
-        <input type="hidden" class="truth-type-value" name="truth-type-${pair_index}" required value="${truth_type}"/>
-        <input type="hidden" class="reference-forecast-value" name="reference-forecast-${pair_index}" required value="${ref_fx_id}"/>
-        <input type="hidden" class="deadband-value" name="deadband-value-${pair_index}" required value="${db_value}"/>
-        <input type="hidden" class="forecast-type-value" name="forecast-type-${pair_index}" required value="${forecast_type}"/>
-    </li>`);
-
-    // Add a 'remove' button for the constant value pair
-    constant_value_pair.append('<a role="button" class="object-pair-delete-button">remove</a>')
-    var remove_button = constant_value_pair.find(".object-pair-delete-button");
-    remove_button.click(function(){
-        constant_value_pair.remove();
-        if (constant_values.find('li').length == 0){
-            // removing the last pair, remove the parent container
-            pair_container.remove();
+        if (forecast_type=='probabilistic_forecast'){
+            $('[name="metrics"][value="crps"]').attr('checked', true);
         }
-        if ($('.object-pair-list .object-pair').length == 0){
-            // if the last pairs were removed, remove the units constraint
-            $('.empty-reports-list')[0].hidden = false;
-            report_utils.unset_units(x => $('#site-select').change());
+
+        // Check for the parent pair container that groups object_pairs
+        // with similar observations, forecasts and uncertainties
+        var pair_container = $(`
+            .pair-container[data-truth-id=${truth_id}][data-fx-id=${distribution_id}][data-deadband-value="${db_value}"]`);
+        if (pair_container.length == 0){
+            pair_container = pairWrapper(
+                truth_type, truth_id, truth_name, fx_id, fx_name, ref_fx_name,
+                db_label, db_value, distribution_id);
+            new_container = true;
         }
-        report_utils.toggle_reference_dependent_metrics();
-    });
 
-    // add the constant value pair to the parent container
-    constant_values.append(constant_value_pair);
+        // Get a handle to the list where we will append constant value pairs
+        var constant_values = pair_container.find('.pair-constant-values');
 
-    // If the parent container was just created, add it to the dom.
-    if (new_container){
-        $('.object-pair-list').append(pair_container);
+        var constant_value_pair = $(`<li class="object-pair object-pair-${pair_index}">
+            <div class="constant-value-label">${constant_value}</div>
+            <div class="object-pair-label reference-forecast-name"><b>Reference Forecast: </b> ${ref_fx_name}</div>
+            <input type="hidden" class="forecast-value" name="forecast-id-${pair_index}" required value="${fx_id}"/>
+            <input type="hidden" class="truth-value" name="truth-id-${pair_index}" required value="${truth_id}"/>
+            <input type="hidden" class="truth-type-value" name="truth-type-${pair_index}" required value="${truth_type}"/>
+            <input type="hidden" class="reference-forecast-value" name="reference-forecast-${pair_index}" required value="${ref_fx_id}"/>
+            <input type="hidden" class="deadband-value" name="deadband-value-${pair_index}" required value="${db_value}"/>
+            <input type="hidden" class="forecast-type-value" name="forecast-type-${pair_index}" required value="${forecast_type}"/>
+        </li>`);
+
+        // Add a 'remove' button for the constant value pair
+        constant_value_pair.append('<a role="button" class="object-pair-delete-button">remove</a>')
+        var remove_button = constant_value_pair.find(".object-pair-delete-button");
+        remove_button.click(function(){
+            constant_value_pair.remove();
+            report_utils.remove_pair(fx_id, truth_id, ref_fx_id, db_label, db_value);
+            if (constant_values.find('li').length == 0){
+                // removing the last pair, remove the parent container
+                pair_container.remove();
+            }
+            if ($('.object-pair-list .object-pair').length == 0){
+                // if the last pairs were removed, remove the units constraint
+                $('.empty-reports-list')[0].hidden = false;
+                report_utils.unset_units(x => $('#site-select').change());
+            }
+            report_utils.toggle_reference_dependent_metrics();
+        });
+
+        // add the constant value pair to the parent container
+        constant_values.append(constant_value_pair);
+
+        // If the parent container was just created, add it to the dom.
+        if (new_container){
+            $('.object-pair-list').append(pair_container);
+        }
+        pair_index++;
     }
-    pair_index++;
 }
 
 

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -29,35 +29,37 @@ function addPair(
      *  @param {string} forecast_type
      *      The type of forecast in the pair.
      */
-
-    var new_object_pair = $(`<div class="pair-container object-pair object-pair-${pair_index}">
-            <div class="input-wrapper">
-              <div class="col-md-12">
-                <div class="object-pair-label forecast-name-${pair_index}"><b>Forecast: </b>${fx_name}</div>
-                <input type="hidden" class="form-control forecast-value" name="forecast-id-${pair_index}" required value="${fx_id}"/>
-                <div class="object-pair-label truth-name-${pair_index}"><b>Observation: </b> ${truth_name}</div>
-                <input type="hidden" class="form-control truth-value" name="truth-id-${pair_index}" required value="${truth_id}"/>
-                <input type="hidden" class="form-control truth-type-value" name="truth-type-${pair_index}" required value="${truth_type}"/>
-                <div class="object-pair-label reference-forecast-name"><b>Reference Forecast: </b> ${ref_fx_name}</div>
-                <input type="hidden" class="form-control reference-forecast-value" name="reference-forecast-${pair_index}" required value="${ref_fx_id}"/>
-                <div class="object-pair-label deadband-label"><b>Uncertainty: </b> ${db_label}</div>
-                <input type="hidden" class="form-control deadband-value" name="deadband-value-${pair_index}" required value="${db_value}"/>
-                <input type="hidden" class="forecast-type-value" required name="forecast-type-${pair_index}" value="${forecast_type}"/>
-              </div>
-             </div>
-             <a role="button" class="object-pair-delete-button">remove</a>
-           </div>`);
-    var remove_button = new_object_pair.find(".object-pair-delete-button");
-    remove_button.click(function(){
-        new_object_pair.remove();
-        if ($('.object-pair-list .object-pair').length == 0){
-            $('.empty-reports-list')[0].hidden = false;
-            report_utils.unset_units(x => $('#site-select').change());
-        }
-        report_utils.toggle_reference_dependent_metrics();
-    });
-    pair_container.append(new_object_pair);
-    pair_index++;
+    if (report_utils.try_insert_pair(fx_id, truth_id, ref_fx_id, db_label, db_value)){
+        var new_object_pair = $(`<div class="pair-container object-pair object-pair-${pair_index}">
+                <div class="input-wrapper">
+                  <div class="col-md-12">
+                    <div class="object-pair-label forecast-name-${pair_index}"><b>Forecast: </b>${fx_name}</div>
+                    <input type="hidden" class="form-control forecast-value" name="forecast-id-${pair_index}" required value="${fx_id}"/>
+                    <div class="object-pair-label truth-name-${pair_index}"><b>Observation: </b> ${truth_name}</div>
+                    <input type="hidden" class="form-control truth-value" name="truth-id-${pair_index}" required value="${truth_id}"/>
+                    <input type="hidden" class="form-control truth-type-value" name="truth-type-${pair_index}" required value="${truth_type}"/>
+                    <div class="object-pair-label reference-forecast-name"><b>Reference Forecast: </b> ${ref_fx_name}</div>
+                    <input type="hidden" class="form-control reference-forecast-value" name="reference-forecast-${pair_index}" required value="${ref_fx_id}"/>
+                    <div class="object-pair-label deadband-label"><b>Uncertainty: </b> ${db_label}</div>
+                    <input type="hidden" class="form-control deadband-value" name="deadband-value-${pair_index}" required value="${db_value}"/>
+                    <input type="hidden" class="forecast-type-value" required name="forecast-type-${pair_index}" value="${forecast_type}"/>
+                  </div>
+                 </div>
+                 <a role="button" class="object-pair-delete-button">remove</a>
+               </div>`);
+        var remove_button = new_object_pair.find(".object-pair-delete-button");
+        remove_button.click(function(){
+            new_object_pair.remove();
+            report_utils.remove_pair(fx_id, truth_id, ref_fx_id, db_label, db_value);
+            if ($('.object-pair-list .object-pair').length == 0){
+                $('.empty-reports-list')[0].hidden = false;
+                report_utils.unset_units(x => $('#site-select').change());
+            }
+            report_utils.toggle_reference_dependent_metrics();
+        });
+        pair_container.append(new_object_pair);
+        pair_index++;
+    }
 }
 
 function createPairSelector(){

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -570,7 +570,6 @@ function createPairSelector(){
             );
             if ($('[name="include-reference"]:checked').val() == "true"
                 && ref_id != null){
-                console.log
                 addPair('aggregate',
                         selected_aggregate.text,
                         selected_aggregate.value,

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -356,13 +356,18 @@ function createPairSelector(){
     var obsSelector = report_utils.newSelector("observation", "forecast");
     var fxSelector = report_utils.newSelector("forecast", "site");
     var refFxSelector = report_utils.newSelector("reference forecast", "forecast", required=false);
+    refFxSelector.find('label').after(report_utils.reference_inclusion_button);
     var fxVariableSelector = report_utils.createVariableSelect();
     var dbSelector = report_utils.deadbandSelector();
     fxSelector.find('.report-field-filters').append(fxVariableSelector);
 
     refFxSelector.append(
         $('<a role="button" id="ref-clear">Clear reference forecast selection</a>').click(
-            function(){$('#reference-forecast-select').val('');})
+            function(){
+                $('#reference-forecast-select').val('');
+                previous_reference_forecast = null;
+            }
+        )
     );
 
     // Buttons for adding an obs/fx pair for observations or aggregates
@@ -509,6 +514,19 @@ function createPairSelector(){
                     deadband_values[0],
                     deadband_values[1],
             );
+            if ($('[name="include-reference"]:checked').val() == "true"
+                && ref_id != null){
+                addPair('observation',
+                        selected_observation.text,
+                        selected_observation.value,
+                        ref_text,
+                        ref_id,
+                        "Unset",
+                        null,
+                        deadband_values[0],
+                        deadband_values[1],
+                );
+            }
             var variable = selected_forecast.dataset.variable;
             report_utils.set_units(variable, filterForecasts);
             $(".empty-reports-list").attr('hidden', 'hidden');
@@ -550,6 +568,20 @@ function createPairSelector(){
                            "Unset",
                            null,
             );
+            if ($('[name="include-reference"]:checked').val() == "true"
+                && ref_id != null){
+                console.log
+                addPair('aggregate',
+                        selected_aggregate.text,
+                        selected_aggregate.value,
+                        ref_text,
+                        ref_id,
+                        "Unset",
+                        null,
+                        deadband_values[0],
+                        deadband_values[1],
+                );
+            }
             var variable = selected_forecast.dataset.variable;
             report_utils.set_units(variable, filterForecasts);
 

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -1457,3 +1457,13 @@ report_utils.register_forecast_fill_method_validator = function(
             .prop('max', 1);
     }
 }
+
+report_utils.reference_inclusion_button = function(){
+    /*
+     * Create a radio button with options for including.
+     */
+    return $(`<div>
+    <input type="radio" name="include-reference" value="true" checked> Also Include as standard Forecast.<br>
+    <input type="radio" name="include-reference" value="false"> Use only for skill metric.<br>
+    </div>`);
+}

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -9,6 +9,8 @@ report_utils = new Object();
 previous_observation = null;
 previous_reference_forecast = null;
 
+// Global for tracking object pairs, used to prevent duplicates.
+object_pairs = [];
 
 report_utils.fill_existing_pairs = function(){
     /*
@@ -1467,4 +1469,56 @@ report_utils.reference_inclusion_button = function(){
     <input type="radio" name="include-reference" value="true" checked> Also include as standard forecast/observation pair with full metrics.<br>
     <input type="radio" name="include-reference" value="false"> Use only for skill metric.<br>
     </div>`);
+}
+
+
+report_utils.compare_object_pairs = function(p1, p2){
+    // Compare object keys
+    var pair_keys = ['forecast', 'observation', 'reference',
+                     'deadband', 'deadband_value'];
+    for (var i =0; i < pair_keys.length; i++){
+        let key = pair_keys[i];
+        if (p1[key] !== p2[key]){
+            return false;
+        }
+    }
+    return true;
+}
+
+report_utils.try_insert_pair = function(fxid, obsid, reffxid, dblabel, dbvalue){
+    /*
+     * Try to add a pair to the object_pair list, returns true on successful
+     * insertion, returns false if the object already exists.
+     */
+    var pair_object = {
+        'forecast': fxid,
+        'observation': obsid,
+        'reference': reffxid,
+        'deadband': dblabel,
+        'deadband_value': dbvalue,
+    }
+    var already_exists = object_pairs.some(
+        x => report_utils.compare_object_pairs(pair_object, x))
+    if (already_exists){
+        return false;
+    } else {
+        object_pairs.push(pair_object);
+        return true;
+    }
+}
+
+report_utils.remove_pair = function(fxid, obsid, reffxid, dblabel, dbvalue){
+    /*
+     * Remove an object pair from the list of object pairs.
+     */
+    var pair_object = {
+        'forecast': fxid,
+        'observation': obsid,
+        'reference': reffxid,
+        'deadband': dblabel,
+        'deadband_value': dbvalue,
+    }
+    object_pairs = object_pairs.filter(
+        x => !report_utils.compare_object_pairs(pair_object, x)
+    )
 }

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -351,7 +351,7 @@ report_utils.applyFxDependentFilters = function(){
     filterReferenceForecasts();
 }
 
-report_utils.newSelector = function(field_name, depends_on=null, required=true){
+report_utils.newSelector = function(field_name, depends_on=null, required=true, description="", classes=[]){
     /*
      * Returns a JQuery object containing labels and select elements with base
      * options.
@@ -380,9 +380,10 @@ report_utils.newSelector = function(field_name, depends_on=null, required=true){
     var field_type = field_name.toLowerCase().replace(/ /g, '-');
     return $(`<div class="form-element full-width ${field_type}-select-wrapper">
                 <label>Select a ${field_name} ${required ? "" : "(Optional)"}</label>
-                  <div class="report-field-filters"><input id="${field_type}-option-search" class="form-control half-width" placeholder="Search by ${field_name} name"/></div><br>
+                  <div class="report-field-filters input-wrapper"><input id="${field_type}-option-search" class="form-control ${field_type == 'reference-forecast' ? '': 'half-width'}" placeholder="Search by ${field_name} name"/></div><br>
+                <div class="selector-description">${description}</div>
                 <div class="input-wrapper">
-                  <select id="${field_type}-select" class="form-control ${field_type}-field" name="${field_type}-select" size="5">
+                  <select id="${field_type}-select" class="form-control ${field_type}-field ${classes.join(" ")}" name="${field_type}-select" size="5">
                   ${depends_on ? `<option id="no-${field_type}-${depends_on}-selection" disabled> Please select a ${depends_on}.</option>` : ""}
                   <option id="no-${field_type}s" disabled hidden>No matching ${field_name}s</option>
                 </select>
@@ -1463,7 +1464,7 @@ report_utils.reference_inclusion_button = function(){
      * Create a radio button with options for including.
      */
     return $(`<div>
-    <input type="radio" name="include-reference" value="true" checked> Also Include as standard Forecast.<br>
+    <input type="radio" name="include-reference" value="true" checked> Also include as standard forecast/observation pair with full metrics.<br>
     <input type="radio" name="include-reference" value="false"> Use only for skill metric.<br>
     </div>`);
 }


### PR DESCRIPTION
Adds options to include reference forecasts as their own forecast, observation pair or to use them only for the skill metric as discussed in https://github.com/SolarArbiter/solarforecastarbiter-core/issues/511. Controlled by a radio button selection just above the selection box. 
A screenshot is included below.
![Screenshot from 2020-09-01 16-29-01](https://user-images.githubusercontent.com/21206164/91915779-4963f000-ec70-11ea-90e9-2c6bd07aa151.png)

Also fixes an issue with retaining reference forecast selection for probabilistic forecasts.
