### PR TITLE
Minor issue cleanup

### DIFF
--- a/sfa_dash/form_utils/utils.py
+++ b/sfa_dash/form_utils/utils.py
@@ -23,7 +23,9 @@ def parse_timedelta_from_form(data_dict, key_root):
         If the units field is not one of 'minutes', 'hours' or 'days', or if
         the number field is not a valid integer.
     """
-    value = int(data_dict[f'{key_root}_number'])
+    # Cast first to float to handle case where user has entered an integer as
+    # a floating point number.
+    value = int(float(data_dict[f'{key_root}_number']))
     units = data_dict[f'{key_root}_units']
     if units == 'minutes':
         return value
@@ -64,12 +66,12 @@ def parse_timedelta_from_api(data_dict, key_root):
     interval_units = 'minutes'
     if interval_minutes % 1440 == 0:
         interval_units = 'days'
-        interval_value = interval_minutes / 1440
+        interval_value = int(interval_minutes / 1440)
     elif interval_minutes % 60 == 0:
         interval_units = 'hours'
-        interval_value = interval_minutes / 60
+        interval_value = int(interval_minutes / 60)
     else:
-        interval_value = interval_minutes
+        interval_value = int(interval_minutes)
     return {
         f'{key_root}_number': interval_value,
         f'{key_root}_units': interval_units,

--- a/sfa_dash/static/js/form-validation.js
+++ b/sfa_dash/static/js/form-validation.js
@@ -83,4 +83,12 @@ $(document).ready(function(){
                 .collapse('hide');
         }
     });
+    $('[name="site_type"]').change(function(){
+        // Enable or disable modeling parameters based on site type
+        if (this.value == 'weather-station'){
+            $('fieldset[name="modeling_parameters"]').prop('disabled', true);
+        } else {
+            $('fieldset[name="modeling_parameters"]').prop('disabled', false);
+        }
+    });
 });

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -18,7 +18,7 @@
 <form action="{{ url_for('forms.create_'+report_type+'_report') }}" method="post" id="report-form" onSubmit="return report_utils.validateReport();">
   <div class="form-group">
      <div class="form-element full-width">
-       <label for="start">Name:</label><br/>
+       <label for="name">Name:</label><br/>
        <div class="input-wrapper">
          <input type="text" class="form-control  name-field" required="" name="name" {{ form.name_validation() }} value="{% if form_data %}{{form_data['report_parameters']['name']}}{% else %}{%endif%}"/>
        </div>

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -18,6 +18,7 @@
 <form action="{{ url_for('forms.create_'+report_type+'_report') }}" method="post" id="report-form" onSubmit="return report_utils.validateReport();">
   <div class="form-group">
      <div class="form-element full-width">
+       <label for="start">Name:</label><br/>
        <div class="input-wrapper">
          <input type="text" class="form-control  name-field" required="" name="name" {{ form.name_validation() }} value="{% if form_data %}{{form_data['report_parameters']['name']}}{% else %}{%endif%}"/>
        </div>

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -66,7 +66,7 @@
 <div class="form-element">
     <label>Constant values</label>
     <div class="input-wrapper">
-        <input type="text" name="constant_values" {% if 'constant_values' in form_data %} value="{{form_data['constant_values']}}"{% endif %} class="form-control constant_values-field" pattern="((\d+)(\.\d+)?)(,\s*\d+(\.\d+)?)*">
+        <input type="text" name="constant_values" required {% if 'constant_values' in form_data %} value="{{form_data['constant_values']}}"{% endif %} class="form-control constant_values-field" pattern="((\d+)(\.\d+)?)(,\s*\d+(\.\d+)?)*">
     </div>
     {{ form.help_button('constant_values') }}
     <span class="help-text text-muted  constant_values-help-text collapse">A comma-separated list of variable values or percentiles for the set of forecasts in the probabilistic forecast. Each value can be a non-negative float or integer. e.g. "5.0,20.0,50.0,80.0,95.0"</span>

--- a/sfa_dash/templates/forms/site_form.html
+++ b/sfa_dash/templates/forms/site_form.html
@@ -32,8 +32,8 @@
 <div class="form-element full-width">
   <label>Site type</label><br/>
   {% set site_type = form_data.get('site_type', None) %}
-  <input type="radio" name="site_type" data-toggle="collapse" data-target=".pv-model-params.show" value="weather-station" class="site_type-field"{% if site_type == 'weather-station' or site_type is none %} checked {% endif %}/>Weather Station
-  <input type="radio" name="site_type" data-toggle="collapse" data-target=".pv-model-params:not(.show)" value="power-plant" class="site_type-field"{% if site_type == 'power-plant' %} checked{% endif %}/>Power Plant
+  <input type="radio" name="site_type" value="weather-station" class="site_type-field"{% if site_type == 'weather-station' or site_type is none %} checked {% endif %}/>Weather Station
+  <input type="radio" name="site_type" value="power-plant" class="site_type-field"{% if site_type == 'power-plant' %} checked{% endif %}/>Power Plant
   {{ form.help_button('site_type') }}
   <span class="site_type-help-text form-text text-muted help-text collapse" aria-hidden>
      Choose Weather Station if the Site will only be used for observations and
@@ -42,8 +42,8 @@
      forecasts of power.
   </span>
 </div>
-<div class="pv-model-params collapse {% if site_type == 'power-plant' %}show{% endif %}">
-  <fieldset name="modeling_parameters">
+<div class="pv-model-params">
+  <fieldset name="modeling_parameters" {% if site_type != 'power-plant' %}disabled{% endif %}>
     <legend>PV modeling parameters</legend>
     <div class="form-element">
     {{ form.input('AC capacity', 'number', 'ac_capacity',


### PR DESCRIPTION
- Casts form fields to integers when necessary during form parsing or api to form conversion to avoid error thrown when string representation float e.g. "1.0" cannot be cast to an int.
- Adds missing `required` attribute to `constant-values` field of cdf forecast forms.
- Always show modeling parameters on site form, disable/enable based on value of the "Site type" field.