### PR TITLE
handle report delete request errors correctly closes #345

### DIFF
--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -404,9 +404,11 @@ class DeleteReportView(BaseView):
         return super().get()
 
     def post(self, uuid):
-        confirmation_url = url_for(f'data_dashboard.delete_report',
-                                   _external=True,
-                                   uuid=uuid)
+        confirmation_url = url_for(
+            'data_dashboard.delete_report',
+            _external=True,
+            uuid=uuid
+        )
         if request.headers['Referer'] != confirmation_url:
             # If the user was directed from anywhere other than
             # the confirmation page, redirect to confirm.
@@ -414,10 +416,11 @@ class DeleteReportView(BaseView):
         try:
             reports.delete(uuid)
         except DataRequestException as e:
-            return self.get(uuid, errors=e.errors)
-        return redirect(url_for(
-            f'data_dashboard.reports',
-            messages={'delete': ['Success']}))
+            self.flash_api_errors(e.errors)
+            return redirect(url_for('data_dashboard.delete_report',
+                                    uuid=uuid))
+        flash("Report deleted successfully")
+        return redirect(url_for('data_dashboard.reports'))
 
 
 class RecomputeReportView(BaseView):

--- a/sfa_dash/templates/forms/deletion_form.html
+++ b/sfa_dash/templates/forms/deletion_form.html
@@ -2,13 +2,19 @@
 {% import "forms/form_macros.jinja" as form %}
 {% set page_title = 'Delete ' + data_type %}
 {% block content %}
+{% if metadata_block is defined %}
 {% if data_type and uuid %}
 {# setting data_type and uuid prints deletion links #}
+{% if is_allowed('delete') %}
 <form action="{{ url_for('data_dashboard.delete_'+data_type, uuid=uuid) }}" method="post" id="delete-form", enctype='application/json'>
   <p>Are you sure you want to delete this resource? This action is irreversible.</p>
   <button type="submit" form="delete-form" value="Submit" class="btn btn-danger btn-sml">Yes</button>
   <a href="{{ url_for('data_dashboard.' + data_type + '_view', uuid=uuid) }}" class="btn btn-primary">No</a>
   {{ form.token() }}
 </form>
-{% endif %}
+{% else %}
+<p>You do not have permission to delete this object.</p>
+{% endif %} {# end delete allowed #}
+{% endif %} {# end if data_type and uuid #}
+{% endif %} {# end if metadata #}
 {% endblock %}


### PR DESCRIPTION
Handles a possible error from trying to delete a report without permissions. Shouldn't really be an issue with recent updates to conditional action display, but this is ready to go.