### PR TITLE
Deletion pairs

### DIFF
--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -249,40 +249,68 @@ class DeleteReportView(BaseView):
         forecast_type = pair['forecast_type']
 
         if forecast_type == 'forecast' or forecast_type == 'event_forecast':
-            forecast_metadata = forecasts.get_metadata(pair['forecast'])
+            try:
+                forecast_metadata = forecasts.get_metadata(pair['forecast'])
+            except DataRequestException:
+                forecast_metadata = None
+
             if pair['reference_forecast'] is not None:
-                reference_metadata = forecasts.get_metadata(
+                try:
+                    reference_metadata = forecasts.get_metadata(
                         pair['reference_forecast'])
+                except DataRequestException:
+                    reference_metadata = None
             else:
                 reference_metadata = None
             forecast_view = 'forecast_view'
         elif forecast_type == 'probabilistic_forecast':
-            forecast_metadata = cdf_forecast_groups.get_metadata(
-                pair['forecast'])
+            try:
+                forecast_metadata = cdf_forecast_groups.get_metadata(
+                    pair['forecast'])
+            except DataRequestException:
+                forecast_metadata = None
+
             if pair.get('reference_forecast') is not None:
-                reference_metadata = cdf_forecast_groups.get_metadata(
-                    pair['reference_forecast'])
+                try:
+                    reference_metadata = cdf_forecast_groups.get_metadata(
+                        pair['reference_forecast'])
+                except DataRequestException:
+                    reference_metadata = None
             else:
                 reference_metadata = None
             forecast_view = 'cdf_forecast_group_view'
         else:
-            forecast_metadata = cdf_forecasts.get_metadata(pair['forecast'])
+            try:
+                forecast_metadata = cdf_forecasts.get_metadata(
+                    pair['forecast'])
+            except DataRequestException:
+                forecast_metadata = None
+
             if pair.get('reference_forecast') is not None:
-                reference_metadata = cdf_forecasts.get_metadata(
-                    pair['reference_forecast'])
+                try:
+                    reference_metadata = cdf_forecasts.get_metadata(
+                        pair['reference_forecast'])
+                except DataRequestException:
+                    reference_metadata = None
             else:
                 reference_metadata = None
             forecast_view = 'cdf_forecast_view'
 
         if pair.get('observation') is not None:
-            observation_metadata = observations.get_metadata(
-                pair['observation'])
+            try:
+                observation_metadata = observations.get_metadata(
+                    pair['observation'])
+            except DataRequestException:
+                observation_metadata = None
         else:
             observation_metadata = None
 
         if pair.get('aggregate') is not None:
-            aggregate_metadata = aggregates.get_metadata(
-                pair['aggregate'])
+            try:
+                aggregate_metadata = aggregates.get_metadata(
+                    pair['aggregate'])
+            except DataRequestException:
+                aggregate_metadata = None
         else:
             aggregate_metadata = None
 
@@ -308,8 +336,18 @@ class DeleteReportView(BaseView):
         object_pairs = params['object_pairs']
         pair_template_args = []
         for pair in object_pairs:
+            pair_args = self._object_pair_template_attributes(pair)
+            # check if the user has access to some metadata before including
+            # the object pair.
+            if (
+                pair_args['forecast'] is None
+                and pair_args['observation'] is None
+                and pair_args['aggregate'] is None
+                and pair_args['reference_forecast'] is None
+            ):
+                continue
             pair_template_args.append(
-               self._object_pair_template_attributes(pair)
+                pair_args
             )
         return pair_template_args
 

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -2,7 +2,8 @@ from flask import (request, redirect, url_for, render_template, send_file,
                    current_app, flash)
 
 from sfa_dash.api_interface import (observations, forecasts, sites, reports,
-                                    aggregates, cdf_forecast_groups, users)
+                                    aggregates, cdf_forecast_groups, users,
+                                    cdf_forecasts)
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.errors import DataRequestException
 from sfa_dash.form_utils import converters
@@ -245,8 +246,6 @@ class DeleteReportView(BaseView):
     def _object_pair_template_attributes(self, pair):
         """Load metadata for objects included in forecast/obs pairs.
         """
-        pair_template_attrs = {}
-
         forecast_type = pair['forecast_type']
 
         if forecast_type == 'forecast' or forecast_type == 'event_forecast':
@@ -260,7 +259,7 @@ class DeleteReportView(BaseView):
         elif forecast_type == 'probabilistic_forecast':
             forecast_metadata = cdf_forecast_groups.get_metadata(
                 pair['forecast'])
-            if pair['reference_forecast'] is not None:
+            if pair.get('reference_forecast') is not None:
                 reference_metadata = cdf_forecast_groups.get_metadata(
                     pair['reference_forecast'])
             else:
@@ -268,42 +267,54 @@ class DeleteReportView(BaseView):
             forecast_view = 'cdf_forecast_group_view'
         else:
             forecast_metadata = cdf_forecasts.get_metadata(pair['forecast'])
-            if pair['reference_forecast'] is not None:
+            if pair.get('reference_forecast') is not None:
                 reference_metadata = cdf_forecasts.get_metadata(
                     pair['reference_forecast'])
             else:
                 reference_metadata = None
             forecast_view = 'cdf_forecast_view'
-        # GET obs/aggregate metadata
-        if pair['observation'] is not None:
-           observation_metadata = observations.get_metadata(
-                pair['observations'])
+
+        if pair.get('observation') is not None:
+            observation_metadata = observations.get_metadata(
+                pair['observation'])
         else:
             observation_metadata = None
 
-        if pair['aggregate'] is not None:
+        if pair.get('aggregate') is not None:
             aggregate_metadata = aggregates.get_metadata(
                 pair['aggregate'])
         else:
             aggregate_metadata = None
 
-        # set uncertainty
         if pair['uncertainty'] == 'observation_uncertainty':
             if observation_metadata is not None:
-               uncertainty = observation_metadata['uncertainty']
+                uncertainty = observation_metadata['uncertainty']
             else:
-               uncertainty = None
+                uncertainty = None
         else:
             uncertainty = pair['uncertainty']
+        return {
+            'forecast': forecast_metadata,
+            'observation': observation_metadata,
+            'aggregate': aggregate_metadata,
+            'reference_forecast': reference_metadata,
+            'uncertainty': uncertainty,
+            'cost': pair['cost'],
+            'forecast_view': forecast_view,
+        }
 
-
-    def load_pair_metadata(self):
-        report_object_pairs = self.metadata['report_parameters']
-        # for each pair, get name and create a link to the dash page
-        # - check for agg or obs
-        # - check for forecast_type
+    def load_pair_template_args(self):
+        params = self.metadata['report_parameters']
+        object_pairs = params['object_pairs']
+        pair_template_args = []
+        for pair in object_pairs:
+            pair_template_args.append(
+               self._object_pair_template_attributes(pair)
+            )
+        return pair_template_args
 
     def set_template_args(self):
+        object_pair_template_args = self.load_pair_template_args()
         self.template_args = {
             'data_type': 'report',
             'uuid': self.metadata['report_id'],
@@ -312,7 +323,8 @@ class DeleteReportView(BaseView):
             'metadata_block': render_template(
                 self.metadata_template,
                 data_type='Report',
-                metadata=self.metadata
+                metadata=self.metadata,
+                object_pairs=object_pair_template_args,
             ),
         }
 

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -292,14 +292,14 @@ class DeleteReportView(BaseView):
             else:
                 uncertainty = None
         else:
-            uncertainty = pair['uncertainty']
+            uncertainty = pair.get('uncertainty')
         return {
             'forecast': forecast_metadata,
             'observation': observation_metadata,
             'aggregate': aggregate_metadata,
             'reference_forecast': reference_metadata,
             'uncertainty': uncertainty,
-            'cost': pair['cost'],
+            'cost': pair.get('cost'),
             'forecast_view': forecast_view,
         }
 

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -242,6 +242,40 @@ class DeleteReportView(BaseView):
     template = 'forms/deletion_form.html'
     metadata_template = 'data/metadata/report_metadata.html'
 
+    def _object_pair_template_attributes(self, pair):
+        pair_template_attrs = {}
+        forecast_type = pair['forecast_type']
+        if forecast_type == 'forecast' or forecast_type == 'event_forecast':
+            forecast_metadata = forecasts.get_metadata(pair['forecast'])
+            if pair['reference_forecast'] is not None:
+                reference_metadata = forecasts.get_metadata(
+                        pair['reference_forecast'])
+            else:
+                reference_metadata = None
+            forecast_view = 'forecast_view'
+        else if forecast_type == 'probabilistic_forecast':
+            forecast_metadata = cdf_forecast_groups.get_metadata(
+                pair['forecast'])
+            if pair['reference_forecast'] is not None:
+                reference_metadata = cdf_forecast_Groups.get_metadata(
+                    pair['reference_forecast'])
+            else:
+                reference_metadata = None
+            forecast_view = 'cdf_forecast_view'
+        else:
+            forecast_metadata = cdf_forecasts.get_metadata(pair['forecast'])
+            if pair['reference_forecast'] is not None:
+            forecast_view = 'cdf_forecast_view'
+        # GET obs/aggregate metadata
+
+        # set uncertainty
+
+    def load_pair_metadata(self):
+        report_object_pairs = self.metadata['report_parameters']
+        # for each pair, get name and create a link to the dash page
+        # - check for agg or obs
+        # - check for forecast_type
+
     def set_template_args(self):
         self.template_args = {
             'data_type': 'report',

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -261,6 +261,30 @@ class DeleteReportView(BaseView):
 
     def _object_pair_template_attributes(self, pair):
         """Load metadata for objects included in forecast/obs pairs.
+
+        Parameters
+        ----------
+        pair:
+            Dict created from an object in the `object_pairs` field of the
+            Solar Forecast Arbiter API report JSON response.
+
+        Returns
+        -------
+        dict:
+            Dict containing the following keys and values:
+            * forecast: dict of forecast metadata or None
+            * observation: dict of observation metadata or None
+            * aggregate: dict of aggregate metadata or None
+            * reference_forecast: dict of forecast metadata or None
+            * uncertainty: dependent on value
+              * float: float
+              * 'observation_uncertainty': The value of the observation's
+                  uncertainty field if available.
+              * None: None
+            * cost: cost value of the pair (str or None)
+            * forecast_view: The name of the forecast view relative to the
+                data_dashboard blueprint e.g. accessible via
+                `data_dashboard.<forecast_view>`.
         """
         forecast_type = pair['forecast_type']
 

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -243,8 +243,12 @@ class DeleteReportView(BaseView):
     metadata_template = 'data/metadata/report_metadata.html'
 
     def _object_pair_template_attributes(self, pair):
+        """Load metadata for objects included in forecast/obs pairs.
+        """
         pair_template_attrs = {}
+
         forecast_type = pair['forecast_type']
+
         if forecast_type == 'forecast' or forecast_type == 'event_forecast':
             forecast_metadata = forecasts.get_metadata(pair['forecast'])
             if pair['reference_forecast'] is not None:
@@ -253,22 +257,45 @@ class DeleteReportView(BaseView):
             else:
                 reference_metadata = None
             forecast_view = 'forecast_view'
-        else if forecast_type == 'probabilistic_forecast':
+        elif forecast_type == 'probabilistic_forecast':
             forecast_metadata = cdf_forecast_groups.get_metadata(
                 pair['forecast'])
             if pair['reference_forecast'] is not None:
-                reference_metadata = cdf_forecast_Groups.get_metadata(
+                reference_metadata = cdf_forecast_groups.get_metadata(
+                    pair['reference_forecast'])
+            else:
+                reference_metadata = None
+            forecast_view = 'cdf_forecast_group_view'
+        else:
+            forecast_metadata = cdf_forecasts.get_metadata(pair['forecast'])
+            if pair['reference_forecast'] is not None:
+                reference_metadata = cdf_forecasts.get_metadata(
                     pair['reference_forecast'])
             else:
                 reference_metadata = None
             forecast_view = 'cdf_forecast_view'
-        else:
-            forecast_metadata = cdf_forecasts.get_metadata(pair['forecast'])
-            if pair['reference_forecast'] is not None:
-            forecast_view = 'cdf_forecast_view'
         # GET obs/aggregate metadata
+        if pair['observation'] is not None:
+           observation_metadata = observations.get_metadata(
+                pair['observations'])
+        else:
+            observation_metadata = None
+
+        if pair['aggregate'] is not None:
+            aggregate_metadata = aggregates.get_metadata(
+                pair['aggregate'])
+        else:
+            aggregate_metadata = None
 
         # set uncertainty
+        if pair['uncertainty'] == 'observation_uncertainty':
+            if observation_metadata is not None:
+               uncertainty = observation_metadata['uncertainty']
+            else:
+               uncertainty = None
+        else:
+            uncertainty = pair['uncertainty']
+
 
     def load_pair_metadata(self):
         report_object_pairs = self.metadata['report_parameters']

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -188,6 +188,14 @@ div.object-pair-list{
   padding-left: 0;
   margin-bottom: 1em;
 }
+ul.object-pair-list{
+    padding-left: 0;
+    list-style: none;
+}
+ul.pair-attribute-list{
+    padding-left: 1em;
+    list-style: none;
+}
 a.object-pair-delete-button, a.error-band-delete-button{
     position: absolute;
     top: 5px;

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -797,7 +797,7 @@ report_utils.cost_fill_field = function(the_div, cost_obj, index=null){
             type="radio"
             id="${report_utils.suffix_name('cost-fill', index)}"
             name="${fill_field_name}"
-            value="mean"
+            value="backward"
             ${cost_obj.fill == 'backward' ? 'checked' : ''}>
            <label for="${report_utils.suffix_name('cost-fill-backward', index)}">backward</label>`);
     const [help_button, help_text] = report_utils.help_popup(

--- a/sfa_dash/templates/data/metadata/meta_macro.jinja
+++ b/sfa_dash/templates/data/metadata/meta_macro.jinja
@@ -29,7 +29,7 @@
 	<li><ul>
     <li><b>Error Range: </b> {{ band['error_range'] }}</li>
 	<li><b>Cost Function: </b>{{ band['cost_function'] }}</li>
-    <li><b>Params: </b>
+    <li><b>Cost Function Parameters: </b>
       <ul>{{ _cost(band['cost_function'], band['cost_function_parameters']) }}
 	  </ul>
     </li>

--- a/sfa_dash/templates/data/metadata/meta_macro.jinja
+++ b/sfa_dash/templates/data/metadata/meta_macro.jinja
@@ -3,3 +3,47 @@
 <li class="metadata-field"><span class="data-metadata-label">{{ label }}: </span>{{ attribute | string | replace("_", " ")}} {% if unit != '' %} ({{ unit }}) {% endif %}</li>
 {% endif %}
 {% endmacro %}
+{% macro _cost(type, params) %}
+{% if type == 'timeofday' %}
+  <li class="metadata-field"><b>Aggregation: </b>{{ params['aggregation'] }}</li>
+  <li class="metadata-field"><b>Times: </b>{{ ', '.join(params['times']) }}</li>
+  <li class="metadata-field"><b>Cost: </b>{% for c in params['cost'] %}{{ c }}{% if not loop.last %}, {% endif %}{% endfor %}</li>
+  <li class="metadata-field"><b>Fill: </b>{{ params['fill'] }}</li>
+  <li class="metadata-field"><b>Net: </b>{{ params['net'] }}</li>
+  <li class="metadata-field"><b>Timezone: </b>{{ params['timezone'] or 'Unset' }}</li>
+  {% elif type == 'constant' %}
+  <li class="metadata-field"><b>Aggregation: </b>{{ params['aggregation'] }}</li>
+  <li class="metadata-field"><b>Cost: </b>{{ params['cost'] }}</li>
+  <li class="metadata-field"><b>Net: </b>{{ params['net'] }}</li>
+  {% elif type == 'datetime' %}
+  <li class="metadata-field"><b>Aggregation: </b>{{ params['aggregation'] }}</li>
+  <li class="metadata-field"><b>Datetimes: </b>{% for d in params['datetimes'] %}{{ d | format_datetime }}{% if not loop.last %}, {% endif %}{% endfor %}</li>
+  <li class="metadata-field"><b>Cost: </b>{% for c in params['cost'] %}{{ c }}{% if not loop.last %}, {% endif %}{% endfor %}</li>
+  <li class="metadata-field"><b>Fill: </b>{{ params['fill'] }}</li>
+  <li class="metadata-field"><b>Net: </b>{{ params['net'] }}</li>
+  <li class="metadata-field"><b>Timezone: </b>{{ params['timezone'] or 'Unset' }}</li>
+  {% elif type == 'errorband' %}
+  <li class="metadata-field"><b>Bands: </b></li>
+  <ul>
+  {% for band in params['bands'] %}
+	<li><ul>
+    <li><b>Error Range: </b> {{ band['error_range'] }}</li>
+	<li><b>Cost Function: </b>{{ band['cost_function'] }}</li>
+    <li><b>Params: </b>
+      <ul>{{ _cost(band['cost_function'], band['cost_function_parameters']) }}
+	  </ul>
+    </li>
+	</ul></li>
+  {% endfor %}
+  </ul>
+  {% endif %}
+{% endmacro %}
+
+{% macro cost(cost) %}
+<li class="metadata-field"><span class="data-metadata-label">{{ cost['name'] }}</span>
+<ul>
+  <li class="metadata-field"><b>Type: </b>{{ cost['type'] }}</li>
+  {{ _cost(cost['type'], cost['parameters']) }}
+</ul>
+</li>
+{% endmacro %}

--- a/sfa_dash/templates/data/metadata/report_metadata.html
+++ b/sfa_dash/templates/data/metadata/report_metadata.html
@@ -58,8 +58,15 @@
 </ul>
 {% endif %}
 <div class="col-md-12 col-sm-12">
+
 <span class="data-metadata-label">Forecasts and Observations:</span>
 <ul class="object-pair-list data-metadata-fields">
+{# Note that this field is populated from a separate object_pairs variable. NOT
+   the 'object_pairs' field of the report metadata. This variable should
+   contain all of the available metadata for each object pair. See docstring of
+   sfa_dash.blueprints.reports.DeleteReportView._object_pair_template_attributes
+   for details.
+#}
 {% if object_pairs | length == 0 %}
 <p>Could not read the metadata of included forecasts and observations.<p>
 {% endif %}

--- a/sfa_dash/templates/data/metadata/report_metadata.html
+++ b/sfa_dash/templates/data/metadata/report_metadata.html
@@ -27,6 +27,7 @@
   </ul>
   </li>
 </ul>
+{% if metadata['report_parameters']['filters'] %}
 <ul class="data-metadata-fields col-md-6 col-sm-12">
   <li class="metadata-field"><span class="data-metadata-label">Filters:</span>
       <ul>
@@ -37,9 +38,72 @@
             {% for value in values %}
             <li>{{ value }}</li>
             {% endfor %}
+          </ul>
+        </li>
         {% endfor %}
         {% endfor %}
       </ul>
   </li>
 </ul>
+{% endif %}
+{% if metadata['report_parameters']['costs'] %}
+<ul class="data-metadata-fields col-md-12 col-sm-12">
+  <li class="metadata-field"><span class="data-metadata-label">Costs:</span>
+      <ul>
+        {% for cost in metadata['report_parameters']['costs'] %}
+        {{ macro.cost(cost) }}
+        {% endfor %}
+      </ul>
+  </li>
+</ul>
+{% endif %}
+<div class="col-md-12 col-sm-12">
+<span class="data-metadata-label">Object Pairs:</span>
+<ul class="object-pair-list data-metadata-fields">
+ {% for pair in object_pairs %}
+ <li class='object-pair-wrapper object-pair'>
+   <div>
+   <ul class="pair-attribute-list">
+     <li><b>Forecast: </b>
+       <a href="
+         {{ url_for('data_dashboard.'+pair['forecast_view'],
+                    uuid=pair['forecast']['forecast_id']) }}">
+         {{pair['forecast']['name']}}
+       </a>
+     </li>
+     {% if pair['observation'] is not none %}
+     <li><b>Observation: </b>
+       <a href="
+         {{url_for('data_dashboard.observation_view',
+                   uuid=pair['observation']['observation_id'])}}">
+         {{ pair['observation']['name'] }}
+       </a>
+     </li>
+     {% endif %}
+     {% if pair['aggregate'] is not none %}
+     <li><b>Aggregate: </b>
+       <a href="
+         {{url_for('data_dashboard.aggregate_view',
+                   uuid=pair['aggregate']['aggregate_id'])}}">
+         {{pair['aggregate']['name']}}
+       </a>
+     </li>
+     {% endif %}
+     {% if pair['reference_forecast'] is not none %}
+     <li><b>Reference Forecast: </b>
+         <a href="
+           {{ url_for('data_dashboard.'+pair['forecast_view'],
+                      uuid=pair['forecast']['forecast_id']) }}">
+             {{pair['reference_forecast']['name']}}
+         </a>
+     </li>
+     {% endif %}
+     <li><b>Uncertainty:</b> {{ pair['uncertainty'] }}</li>
+     <li><b>Cost:</b> {{ pair['cost'] }}</li>
+   </ul>
+   </div>
+ </li>
+ {% endfor %}
+</ul>
+</div>
 {% endblock %}

--- a/sfa_dash/templates/data/metadata/report_metadata.html
+++ b/sfa_dash/templates/data/metadata/report_metadata.html
@@ -58,18 +58,26 @@
 </ul>
 {% endif %}
 <div class="col-md-12 col-sm-12">
-<span class="data-metadata-label">Object Pairs:</span>
+<span class="data-metadata-label">Forecasts and Observations:</span>
 <ul class="object-pair-list data-metadata-fields">
- {% for pair in object_pairs %}
+{% if object_pairs | length == 0 %}
+<p>Could not read the metadata of included forecasts and observations.<p>
+{% endif %}
+{% for pair in object_pairs %}
  <li class='object-pair-wrapper object-pair'>
    <div>
    <ul class="pair-attribute-list">
      <li><b>Forecast: </b>
+
+       {% if pair['forecast'] is not none %}
        <a href="
          {{ url_for('data_dashboard.'+pair['forecast_view'],
                     uuid=pair['forecast']['forecast_id']) }}">
          {{pair['forecast']['name']}}
        </a>
+       {% else %}
+       Could not read Forecast.
+       {% endif %}
      </li>
      {% if pair['observation'] is not none %}
      <li><b>Observation: </b>


### PR DESCRIPTION
closes #234 
Adds object pairs with link names and cost parameters to the report metadata block of delete report pages. Names of each object are links to their dashboard page.
![report_w_pairs_costs](https://user-images.githubusercontent.com/21206164/95516244-cff8a500-0973-11eb-8b69-0bee62b43c2a.png)
