### PR TITLE
Allow report viewing with partial permissions

### DIFF
--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -735,7 +735,10 @@ class PermissionObjectAddition(PermissionView):
                 all_objects = self.flatten_reports(all_objects)
 
             # remove any objects already on the permission
-            object_id_key = f"{data_type}_id"
+            if 'forecast' in data_type:
+                object_id_key = 'forecast_id'
+            else:
+                object_id_key = f"{data_type}_id"
             all_objects = [obj for obj in all_objects
                            if obj[object_id_key] not in perm_objects]
             self.set_template_args(permission)

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -175,15 +175,18 @@ class ReportView(BaseView):
             report_kwargs.pop('scatter_spec', None)
             if not include_timeseries and report_status == 'complete':
                 flash(
-                    f"""<strong>Warning</strong> To improve performance
-                    timeseries plots have been omitted from this report. You
-                    may download a copy of this report with the timeseries
-                    plots included:
+                    f"""<strong>Warning</strong> Too many timeseries points
+                    detected. To improve performance time series plots have
+                    been omitted from this report. You may download a copy
+                    of this report with the timeseries plots included:
                     <a href="{download_link}">Download HTML Report.</a>""",
                     'warning')
             elif not self.metadata['values'] and report_status == 'complete':
-                flash('Could not load report values. Timeseries and scatter '
-                      'plots will not be included.',
+                flash('Could not load any time series values of observations '
+                      'or forecasts. Timeseries and scatter plots will not '
+                      'be included. You may require the `read_values` '
+                      'permission on this report, or the included forecasts '
+                      'and observations.',
                       'warning')
         self.template_args = report_kwargs
 

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -213,6 +213,8 @@ class DownloadReportView(ReportView):
             errors = {'errors': e.errors}
             return ReportView().get(uuid, errors=errors)
 
+        exclude_timeseries = 'exclude_timeseries' in request.args
+
         # don't do the work of making a report if the format is incorrect
         if self.format_ not in ('html', 'pdf'):
             raise ValueError(
@@ -226,7 +228,7 @@ class DownloadReportView(ReportView):
             bytes_out = render_html(
                 report_object,
                 request.url_root.rstrip('/'),
-                with_timeseries=True, body_only=False
+                with_timeseries=not exclude_timeseries, body_only=False
             ).encode('utf-8')
         elif self.format_ == 'pdf':
             bytes_out = render_pdf(

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -165,29 +165,26 @@ class ReportView(BaseView):
         })
         # If we're not including timeseries, or values could not be read,
         # pop all of the timeseries/scatter spec template arguments
-        if not include_timeseries or not self.metadata['values']:
-            report_status = self.metadata.get('status')
-            # display a message about omitting timeseries
+        report_status = self.metadata.get('status')
+
+        # display a message about omitting timeseries
+        if not include_timeseries and report_status == 'complete':
             download_link = url_for('data_dashboard.download_report_html',
                                     uuid=self.metadata['report_id'])
-            report_kwargs.pop('timeseries_spec', None)
-            report_kwargs.pop('timeseries_prob_spec', None)
-            report_kwargs.pop('scatter_spec', None)
-            if not include_timeseries and report_status == 'complete':
-                flash(
-                    f"""<strong>Warning</strong> Too many timeseries points
-                    detected. To improve performance time series plots have
-                    been omitted from this report. You may download a copy
-                    of this report with the timeseries plots included:
-                    <a href="{download_link}">Download HTML Report.</a>""",
-                    'warning')
-            elif not self.metadata['values'] and report_status == 'complete':
-                flash('Could not load any time series values of observations '
-                      'or forecasts. Timeseries and scatter plots will not '
-                      'be included. You may require the `read_values` '
-                      'permission on this report, or the included forecasts '
-                      'and observations.',
-                      'warning')
+            flash(
+                f"""<strong>Warning</strong> Too many timeseries points
+                detected. To improve performance time series plots have
+                been omitted from this report. You may download a copy
+                of this report with the timeseries plots included:
+                <a href="{download_link}">Download HTML Report.</a>""",
+                'warning')
+        elif not self.metadata['values'] and report_status == 'complete':
+            flash('Could not load any time series values of observations '
+                  'or forecasts. Timeseries and scatter plots will not '
+                  'be included. You may require the `read_values` '
+                  'permission on this report, or the included forecasts '
+                  'and observations.',
+                  'warning')
         self.template_args = report_kwargs
 
     def set_metadata(self, uuid):

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -181,7 +181,7 @@ class ReportView(BaseView):
                     plots included:
                     <a href="{download_link}">Download HTML Report.</a>""",
                     'warning')
-            elif not self.metadata['values'] and report_status == 'success':
+            elif not self.metadata['values'] and report_status == 'complete':
                 flash('Could not load report values. Timeseries and scatter '
                       'plots will not be included.',
                       'warning')

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -163,8 +163,6 @@ class ReportView(BaseView):
             'metadata': {
                 'report_parameters': self.metadata['report_parameters']},
         })
-        # If we're not including timeseries, or values could not be read,
-        # pop all of the timeseries/scatter spec template arguments
         report_status = self.metadata.get('status')
 
         # display a message about omitting timeseries

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -173,7 +173,7 @@ class ReportView(BaseView):
             report_kwargs.pop('timeseries_spec', None)
             report_kwargs.pop('timeseries_prob_spec', None)
             report_kwargs.pop('scatter_spec', None)
-            if not include_timeseries and report_status == 'success':
+            if not include_timeseries and report_status == 'complete':
                 flash(
                     f"""<strong>Warning</strong> To improve performance
                     timeseries plots have been omitted from this report. You

--- a/sfa_dash/templates/data/intermediate_report.html
+++ b/sfa_dash/templates/data/intermediate_report.html
@@ -15,7 +15,8 @@
 {% set report_url = dash_url + '/reports/'+ report['report_id'] %}
 <p>
   This report can be downloaded as a
-  <a href="{{ report_url + '/download/html' }}">standalone HTML file</a> or
+  <a href="{{ report_url + '/download/html' }}">standalone HTML file</a>,
+  <a href="{{ report_url + '/download/html?exclude_timeseries=true' }}">standalone HTML file without timeseries</a> or
   <a href="{{ report_url + '/download/pdf' }}">PDF file</a>.
   The download is a ZIP archive that includes checksums for the
   report file and a PGP signature that can be used to verify the

--- a/sfa_dash/templates/forms/admin/permission_macros.jinja
+++ b/sfa_dash/templates/forms/admin/permission_macros.jinja
@@ -2,10 +2,10 @@
 {% autoescape true %}
 {% if data_type == 'observation' %}
   {% set uuid = row_values['observation_id'] %}
-{% elif data_type == 'forecast' %}
-  {% set uuid = row_values['forecast_id'] %}
 {% elif data_type == 'aggregate' %}
   {% set uuid = row_values['aggregate_id'] %}
+{% elif 'forecast' in data_type %}
+  {% set uuid = row_values['forecast_id'] %}
 {% endif %}
 <tr visible="true">
   <td><input type="checkbox" name="objects-list-{{ index }}" value="{{ uuid }}" {% if checked %}checked{% endif %}></td>


### PR DESCRIPTION
closes #134 
Relies on https://github.com/SolarArbiter/solarforecastarbiter-api/pull/280.
Removes the timeseries/scatter plot specifications from the report template arguments if the report `values` field is empty or if the maximum number of data points to plot is exceeded. 

This also fixes a bug where if the maximum datapoints were exceeded the warning was not displayed. This was something missed in the migration to plotly. The warning message is now displayed at the top of the page in the message section, since Plotly does not have a `<div>` to override with a message like bokeh did.