### PR TITLE
Handle connectionerror

### DIFF
--- a/sfa_dash/api_interface/__init__.py
+++ b/sfa_dash/api_interface/__init__.py
@@ -43,8 +43,9 @@ def get_request(path, **kwargs):
         capture_exception(e)
         # The api hung up, handle an error, attempts to reconnect can work
         # but often fail to reconnect and raise a different exception
-        raise DataRequestException(
-            'API connection failed. Please wait a moment and try again.')
+        raise DataRequestException(503, {
+            'Error': 'API connection failed. Please try again.'
+        })
     else:
         return handle_response(req)
 

--- a/sfa_dash/api_interface/tests/app.py
+++ b/sfa_dash/api_interface/tests/app.py
@@ -58,5 +58,10 @@ def always():
     return resp
 
 
+@test_app.route('/kill')
+def hangup():
+    sys.exit()
+
+
 if __name__ == '__main__':
     test_app.run(port=sys.argv[1])

--- a/sfa_dash/api_interface/tests/test_init.py
+++ b/sfa_dash/api_interface/tests/test_init.py
@@ -89,7 +89,7 @@ def test_bad_length(context, background_server):
 
 def test_bad_length_retries_exhausted(context, background_server):
     context.config['SFA_API_URL'] = background_server
-    with pytest.raises(requests.exceptions.ChunkedEncodingError):
+    with pytest.raises(DataRequestException):
         api_interface.get_request('/alwaysfail')
 
 

--- a/sfa_dash/api_interface/tests/test_init.py
+++ b/sfa_dash/api_interface/tests/test_init.py
@@ -11,6 +11,7 @@ import requests
 
 
 from sfa_dash import api_interface
+from sfa_dash.errors import DataRequestException
 
 
 @pytest.fixture()
@@ -90,3 +91,9 @@ def test_bad_length_retries_exhausted(context, background_server):
     context.config['SFA_API_URL'] = background_server
     with pytest.raises(requests.exceptions.ChunkedEncodingError):
         api_interface.get_request('/alwaysfail')
+
+
+def test_get_request_connection_error(context, background_server):
+    context.config['SFA_API_URL'] = background_server
+    with pytest.raises(DataRequestException):
+        api_interface.get_request('/kill')

--- a/sfa_dash/conftest.py
+++ b/sfa_dash/conftest.py
@@ -14,6 +14,7 @@ BASE_URL = 'http://localhost'
 
 resample_threshold = QFF.resample_threshold_percentage
 
+
 @pytest.fixture(scope='session')
 def auth_token():
     token_req = requests.post(


### PR DESCRIPTION
closes #369 
Catches connection errors and retries. I've added different logic here to catch and report failures between chunked encoding errors and connection errors after retries to sentry, then tell the user that the api connection failed and to try again.