### PR TITLE
Delete obs from aggregate

### DIFF
--- a/sfa_dash/api_interface/aggregates.py
+++ b/sfa_dash/api_interface/aggregates.py
@@ -32,3 +32,9 @@ def update(aggregate_id, updates):
 def delete(aggregate_id):
     req = delete_request(f'/aggregates/{aggregate_id}')
     return req
+
+
+def delete_observation(aggregate_id, observation_id):
+    req = delete_request(
+        f'/aggregates/{aggregate_id}/observations/{observation_id}')
+    return req

--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -1,4 +1,4 @@
-from flask import render_template, url_for, request, redirect
+from flask import render_template, url_for, request, redirect, flash
 import pandas as pd
 
 from sfa_dash.api_interface import observations, sites, aggregates
@@ -361,6 +361,14 @@ class AggregateView(BaseView):
                     observation = observation_dict[curr_id].copy()
                     observation.update(obs)
                     self.observation_list.append(observation)
+                else:
+                    flash(
+                        f"Could not read observation '{obs['observation_id']}'"
+                        " you may require `read` or `read_values` permissions "
+                        "to view this aggregate properly.",
+                        "warning"
+                    )
+                    self.observation_list.append(obs)
             self.insert_plot(uuid, start, end)
             self.set_template_args(start, end, **kwargs)
         return render_template(self.template, **self.template_args)

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -7,7 +7,8 @@ from sfa_dash.api_interface import (sites, observations, forecasts,
                                     cdf_forecasts, cdf_forecast_groups,
                                     aggregates)
 from sfa_dash.blueprints.aggregates import (AggregateObservationAdditionForm,
-                                            AggregateObservationRemovalForm)
+                                            AggregateObservationRemovalForm,
+                                            AggregateObservationDeletionForm)
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.blueprints.reports import (ReportForm, RecomputeReportView,
                                          ReportCloneView)
@@ -496,7 +497,9 @@ forms_blp.add_url_rule('/aggregates/<uuid>/add',
 forms_blp.add_url_rule('/aggregates/<uuid>/remove/<observation_id>',
                        view_func=AggregateObservationRemovalForm.as_view(
                            'remove_aggregate_observations'))
-
+forms_blp.add_url_rule('/aggregates/<uuid>/delete/<observation_id>',
+                       view_func=AggregateObservationDeletionForm.as_view(
+                           'delete_aggregate_observations'))
 # update endpoints
 forms_blp.add_url_rule('/sites/<uuid>/update',
                        view_func=UpdateForm.as_view('update_site',

--- a/sfa_dash/form_utils/tests/test_converter.py
+++ b/sfa_dash/form_utils/tests/test_converter.py
@@ -187,7 +187,8 @@ def test_observation_converter_formdata_to_payload(observation):
     }
 
 
-def test_observation_converter_formdata_to_payload(observation):
+def test_observation_converter_formdata_to_payload_empty_uncertainty(
+        observation):
     form_data = {
         'name': 'GHI Instrument 1',
         'variable': 'ghi',

--- a/sfa_dash/templates/data/aggregate.html
+++ b/sfa_dash/templates/data/aggregate.html
@@ -43,7 +43,14 @@
     </tr>
     {% for obs in observations %}
     <tr class="aggregate-observation-row">
-        <td scope="col"><a href="{{ url_for('data_dashboard.observation_view', uuid=obs["observation_id"]) }}">{{ obs["name"] }}</a></td>
+        <td scope="col">
+          {% if 'name' in obs %}
+          <a href="{{ url_for('data_dashboard.observation_view', uuid=obs["observation_id"]) }}">{{ obs["name"] }}</a>
+          {% else %}
+          {{ obs['observation_id'] }}
+          {% endif %}
+        </td>
+
         <td scope="col" class="provider-column">{{ obs["provider"] }}</td>
         <td scope="col" class="effective-from-column datetime-td">{{ obs["effective_from"] | format_datetime}}</td>
         {% if obs["effective_until"] is not none %}

--- a/sfa_dash/templates/data/aggregate.html
+++ b/sfa_dash/templates/data/aggregate.html
@@ -41,29 +41,42 @@
     <tr class="warning no-result">
       <td colspan="4"><i class="fa fa-warning"></i>No result</td> 
     </tr>
-    {% for obs in observations %}
+    {% for _, obs in observations.items() %}
+    {% for ef in obs['effective_ranges'] %}
     <tr class="aggregate-observation-row">
-        <td scope="col">
+        {# print name and org columns to span all of the rows of effective_ranges #}
+        {% if loop.index == 1 %}
+        <td scope="col" rowspan={{ obs['effective_ranges'] | length }}>
           {% if 'name' in obs %}
           <a href="{{ url_for('data_dashboard.observation_view', uuid=obs["observation_id"]) }}">{{ obs["name"] }}</a>
           {% else %}
           {{ obs['observation_id'] }}
           {% endif %}
         </td>
-
-        <td scope="col" class="provider-column">{{ obs["provider"] }}</td>
-        <td scope="col" class="effective-from-column datetime-td">{{ obs["effective_from"] | format_datetime}}</td>
-        {% if obs["effective_until"] is not none %}
-        <td scope="col" class="effective-until-column datetime-td">{{ obs["effective_until"] | format_datetime}}</td>
+        <td scope="col" class="provider-column" rowspan={{ obs['effective_ranges'] | length }}>{{ obs["provider"] }}</td>
+        {% endif %}
+        <td scope="col" class="effective-from-column datetime-td">{{ ef["effective_from"] | format_datetime}}</td>
+        {% if ef["effective_until"] is not none %}
+        <td scope="col" class="effective-until-column datetime-td">{{ ef["effective_until"] | format_datetime}}</td>
         {% else %}
+        <td scope="col">
         {% if update_allowed %}
-        <td scope="col"><a href="{{ url_for('forms.remove_aggregate_observations', uuid=metadata['aggregate_id'], observation_id=obs['observation_id']) }}">Set Effective Until</a></td>
+        <a href="{{ url_for('forms.remove_aggregate_observations', uuid=metadata['aggregate_id'], observation_id=obs['observation_id']) }}">Set Effective Until</a>
+        {% else %}
+        {{ ef["effective_until"] }}
         {% endif %}
+        </td>
         {% endif %}
+        {# only print the delete button once per observation #}
+        {% if loop.index == 1 %}
+        <td scope="col" rowspan={{ obs['effective_ranges'] | length }}>
         {% if update_allowed %}
-        <td scope="col"><a role="button" class="btn btn-sm btn-danger" href="{{ url_for('forms.delete_aggregate_observations', uuid=metadata['aggregate_id'], observation_id=obs['observation_id']) }}">Delete</a></td>
+        <a role="button" class="btn btn-sm btn-danger" href="{{ url_for('forms.delete_aggregate_observations', uuid=metadata['aggregate_id'], observation_id=obs['observation_id']) }}">Delete</a></td>
+        {% endif %}
+        </td>
         {% endif %}
     </tr>
+    {% endfor %}
     {% endfor %}
   </tbody>
 </table>

--- a/sfa_dash/templates/data/aggregate.html
+++ b/sfa_dash/templates/data/aggregate.html
@@ -35,6 +35,7 @@
       <button type="button" class="btn btn-th dropdown-toggle" data-toggle="collapse" data-target="#org-filters" >Organization</button></th>
     <th scope="col">Effective From</th>
     <th scope="col">Effective Until</th>
+    <th scope="col"></th>
   </thead>
   <tbody>
     <tr class="warning no-result">
@@ -51,6 +52,9 @@
         {% if update_allowed %}
         <td scope="col"><a href="{{ url_for('forms.remove_aggregate_observations', uuid=metadata['aggregate_id'], observation_id=obs['observation_id']) }}">Set Effective Until</a></td>
         {% endif %}
+        {% endif %}
+        {% if update_allowed %}
+        <td scope="col"><a role="button" class="btn btn-sm btn-danger" href="{{ url_for('forms.delete_aggregate_observations', uuid=metadata['aggregate_id'], observation_id=obs['observation_id']) }}">Delete</a></td>
         {% endif %}
     </tr>
     {% endfor %}

--- a/sfa_dash/templates/forms/aggregate_observation_deletion_form.html
+++ b/sfa_dash/templates/forms/aggregate_observation_deletion_form.html
@@ -1,0 +1,40 @@
+{% import "forms/form_macros.jinja" as form %}
+{% extends "dash/data.html" %}
+{% block content %}
+{% if aggregate is defined and observation is defined %}
+<h3>Delete Observation from an Aggregate</h3>
+<p></p>
+<table class="table">
+    <thead><th>Observation</th><th>Effective From</th><th>Effective Until</th></thead>
+  <tbody>
+  {% for obs in aggregate['observations'] %}
+  {% if obs['observation_id'] == observation['observation_id'] %}
+  <tr>
+    <td>{% if 'name' in observation %}
+        {{ observation['name'] }}
+        {% else %}
+        {{ obs['observation_id'] }}
+        {% endif %}
+    </td>
+    <td>{{ obs['effective_from'] |format_datetime}}</td>
+    <td>{{ obs['effective_until'] }} </td>
+  </tr>
+  {% endif %}
+  {% endfor %}
+  </tbody>
+</table>
+<form action="{{ url_for('forms.delete_aggregate_observations', uuid=aggregate['aggregate_id'], observation_id=observation['observation_id']) }}" method="post" enctype="application/json" id="delete-aggregate-observations-form">
+  <div class="form-group">
+    <div class="form-element full-width">
+      <p>Are you sure you want to delete the observation from this aggregate?
+         All of the effective times in the table above will be removed.
+         This action is irreversible.
+      </p>
+      <button type="submit" form="delete-aggregate-observations-form" value="Submit" class="btn btn-danger btn-sml">Yes</button>
+      <a href="{{ url_for('data_dashboard.aggregate_view', uuid=aggregate['aggregate_id']) }}" class="btn btn-primary">No</a>
+  </div>
+  {{ form.token() }}
+  </div>
+</form>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Adds a delete button to the aggregate observation table if the user has `update` permission.
![Screenshot from 2020-10-23 16-52-43](https://user-images.githubusercontent.com/21206164/97062537-396ddb80-1550-11eb-84f5-300622c17c57.png)
The deletion confirmation page displays a table of the times the observation has been added to the aggregate, and warns the user that they are removing all of them.
![Screenshot from 2020-10-23 16-55-08](https://user-images.githubusercontent.com/21206164/97062622-95386480-1550-11eb-964d-6ff76d6305ee.png)
