### PR TITLE
CRPSS

### DIFF
--- a/sfa_dash/form_utils/converters.py
+++ b/sfa_dash/form_utils/converters.py
@@ -557,7 +557,8 @@ class ReportConverter(FormConverter):
     @classmethod
     def apply_crps(cls, params):
         """Checks for "probabilistic_forecast' forecast_type in object pairs
-        and if found, appends the CRPS metric to the metrics options.
+        and if found, appends the CRPS metric to the metrics options. If a
+        reference forecast is also selected, applies CRPSS metric.
         """
         new_params = params.copy()
         pair_fx_types = [f['forecast_type'] for f in params['object_pairs']]

--- a/sfa_dash/form_utils/converters.py
+++ b/sfa_dash/form_utils/converters.py
@@ -559,13 +559,20 @@ class ReportConverter(FormConverter):
         """Checks for "probabilistic_forecast' forecast_type in object pairs
         and if found, appends the CRPS metric to the metrics options.
         """
+        new_params = params.copy()
         pair_fx_types = [f['forecast_type'] for f in params['object_pairs']]
         if'probabilistic_forecast' in pair_fx_types:
-            new_params = params.copy()
             new_params['metrics'].append('crps')
-            return new_params
-        else:
-            return params
+
+        contains_distribution_with_reference = any([
+            f['forecast_type'] == 'probabilistic_forecast'
+            and f['reference_forecast'] is not None
+            for f in params['object_pairs']])
+
+        if contains_distribution_with_reference:
+            new_params['metrics'].append('crpss')
+
+        return new_params
 
     @classmethod
     def parse_fill_method(cls, form_dict):

--- a/sfa_dash/form_utils/tests/test_converter.py
+++ b/sfa_dash/form_utils/tests/test_converter.py
@@ -601,3 +601,31 @@ def test_report_converter_stringify_infinity(error_range, expected):
          ]
     )
     assert result[0]['parameters']['bands'][0]['error_range'] == expected
+
+
+@pytest.mark.parametrize('pair,expected_metrics', [
+    ({'observation': 'a',
+      'forecast': 'b',
+      'reference_forecast': None,
+      'forecast_type': 'forecast',
+      },
+      [],
+    ), ({'observation': 'a',
+         'forecast': 'b',
+         'reference_forecast': None,
+         'forecast_type': 'probabilistic_forecast',
+         },
+         ['crps'],
+    ),({'observation': 'a',
+        'forecast': 'b',
+        'reference_forecast': 'c',
+        'forecast_type': 'probabilistic_forecast',
+       },
+       ['crps', 'crpss'],
+    ),
+])
+def test_report_converter_apply_crps_crpss(pair, expected_metrics):
+    params = {'object_pairs': [pair], 'metrics': []}
+    updated = converters.ReportConverter.apply_crps(params)
+    assert updated['metrics'] == expected_metrics
+

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -16,8 +16,7 @@ object_pairs = [];
 // messages for in the toggle_reference_dependent_metrics function.
 reference_dependent_metrics = ['[name=metrics][value=s]',
                                '[name=metrics][value=bss]',
-                               '[name=metrics][value=qss]',
-                               '[name=metrics][value=crpss]'];
+                               '[name=metrics][value=qss]'];
 
 report_utils.fill_existing_pairs = function(){
     /*

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -16,7 +16,8 @@ object_pairs = [];
 // messages for in the toggle_reference_dependent_metrics function.
 reference_dependent_metrics = ['[name=metrics][value=s]',
                                '[name=metrics][value=bss]',
-                               '[name=metrics][value=qss]'];
+                               '[name=metrics][value=qss]',
+                               '[name=metrics][value=crpss]'];
 
 report_utils.fill_existing_pairs = function(){
     /*
@@ -147,7 +148,7 @@ report_utils.toggle_reference_dependent_metrics = function(){
             let metric = $(metric_selector);
             if (metric.length){
                 // hide skill, insert warning
-                if ($('#reference-warning').length == 0){
+                if ($('.reference-warning.warning-message').length == 0){
                     $(`<span class="reference-warning warning-message">
                        (Requires reference forecast selection)</span>`
                      ).insertAfter(metric.next());

--- a/sfa_dash/templates/forms/probabilistic_report_form.html
+++ b/sfa_dash/templates/forms/probabilistic_report_form.html
@@ -3,8 +3,8 @@
 {% set report_type = 'probabilistic' %}
 {% set report_script = '/static/js/probabilistic-report-form-handling.js' %}
 {% set constant_value_metric_options = probabilistic_metrics %}
-{% set excluded_constant_value_metrics = ['crps'] %}
-{% set full_group_metric_options = {'crps': 'CRPS'} %}
+{% set excluded_constant_value_metrics = ['crps', 'crpss'] %}
+{% set full_group_metric_options = {'crps': 'CRPS', 'crpss': 'CRPSS'} %}
 
 
 {% extends "forms/base/base_report_form.html" %}


### PR DESCRIPTION
Adds CRPSS to the reference dependent metric listing so that a warning appears when no reference forecast is selected. Also fixes issue with multiple warnings. This should be all that's needed when CRPSS is added in core, as the list of metrics is built from `solarforecastarbiter.datamodel.ALLOWED_PROBABILISTIC_METRICS`.