### PR TITLE
Fix bug in column filters

### DIFF
--- a/sfa_dash/static/js/table-search.js
+++ b/sfa_dash/static/js/table-search.js
@@ -78,8 +78,11 @@ $(document).ready(function() {
         rowsToHide = $([]);
         $(optionSelector).each(function (e){
             if (!this.checked){
+                let value = this.value;
                 rowsToHide = rowsToHide.add(
-                    $(`${columnSelector}:contains("${this.value}")`).parent());
+                    $(columnSelector).filter(function(){
+                        return $(this).text() == value;
+                    }).parent());
             }
         });
         return rowsToHide


### PR DESCRIPTION
Adjusts column filterting to check for exact match instead of 'contains'. Things like "read" on the permissions table were hiding columns for "read_values"