### PR TITLE
copy uuid button, fix report listing popups

### DIFF
--- a/sfa_dash/static/js/report-listing.js
+++ b/sfa_dash/static/js/report-listing.js
@@ -1,8 +1,21 @@
 $(document).ready(function() {
     $('.report-details-expander').click(function(){
+        // Close any other open report details
+        $('div.report-metadata-popup[hidden!=hidden]').attr('hidden', true);
         $(this).next().removeAttr('hidden');
     });
     $('.report-details-closer').click(function(){
         $(this).parent().attr('hidden', true);
     });
 })
+$(document).click(function(event){
+    let target = $(event.target);
+    // first check that the user didn't click the expander button
+    if (!target.closest('.report-details-expander').length){
+        // if there is no popup in the target, close all popups.
+        if (!target.closest('div.report-metadata-popup').length){
+            $('div.report-metadata-popup[hidden!=hidden]').attr('hidden', true);
+        }
+    }
+
+});

--- a/sfa_dash/static/js/utils.js
+++ b/sfa_dash/static/js/utils.js
@@ -1,0 +1,21 @@
+$(document).ready(function(){
+    if ($("#object_uuid").length) {
+        // Add a button link to copy uuids
+        $("#object_uuid").after(
+            $("<br/>"),
+            $("<a>")
+                .attr("role", "button")
+                .css("color", "#007bff")
+                .text("Copy UUID")
+                .click(function(){
+                    window.getSelection().removeAllRanges();
+                    let uuid_container = document.getElementById("object_uuid");
+                    let range = document.createRange();
+                    range.selectNode(uuid_container);
+                    window.getSelection().addRange(range);
+                    document.execCommand("copy");
+                })
+        );
+    }
+
+});

--- a/sfa_dash/templates/data/metadata/aggregate_metadata.html
+++ b/sfa_dash/templates/data/metadata/aggregate_metadata.html
@@ -4,6 +4,7 @@
 {% block metadata %}
 <ul class="data-metadata-fields col-md-6 col-sm-12">
       {{ macro.li('Name', name) }}
+      {{ macro.uuid(aggregate_id) }}
       {{ macro.li('Description', description) }}
       {{ macro.li('Timezone', timezone ) }}
 </ul>

--- a/sfa_dash/templates/data/metadata/data_metadata.html
+++ b/sfa_dash/templates/data/metadata/data_metadata.html
@@ -6,6 +6,24 @@
 {% block metadata %}
 <ul class="data-metadata-fields col-md-6 col-sm-12">
       {{ macro.li('Name', name) }}
+      {# select the correct uuid for printing #}
+      {% if site_id is defined %}
+        {% if forecast_id is defined %}
+          {% set uuid = forecast_id %}
+        {% elif observation_id is defined %}
+          {% set uuid = observation_id %}
+        {% else %}
+          {% set uuid = site_id %}
+        {% endif %}
+      {% elif aggregate_id is defined %}
+        {% if forecast_id is defined %}
+          {% set uuid = forecast_id %}
+        {% else %}
+          {% set uuid = aggregate_id %}
+        {% endif %}
+      {% endif %}
+      {{ macro.uuid(uuid) }}
+
       {% if site_link is defined %}
         {{ macro.li('Site', site_link )}}
       {% elif location_link is defined %}
@@ -16,6 +34,7 @@
         {% endif %}
         {{ macro.li(location_label, location_link) }}
       {% endif %}
+
 </ul>
 <ul class="data-metadata-fields col-md-6 col-sm-12">
   {{ macro.li('Variable', variable |convert_varname, variable | var_to_units) }}

--- a/sfa_dash/templates/data/metadata/meta_macro.jinja
+++ b/sfa_dash/templates/data/metadata/meta_macro.jinja
@@ -47,3 +47,7 @@
 </ul>
 </li>
 {% endmacro %}
+
+{% macro uuid(the_uuid) %}
+<li class="metadata-field"><span class="data-metadata-label">UUID: </span><span id="object_uuid">{{ the_uuid | string }}</span></li>
+{% endmacro %}

--- a/sfa_dash/templates/data/metadata/report_macro.jinja
+++ b/sfa_dash/templates/data/metadata/report_macro.jinja
@@ -2,6 +2,7 @@
 {% macro report_metadata(metadata, all_metrics, metric_categories, object_pairs) %}
 <ul class="data-metadata-fields col-md-6 col-sm-12">
       {{ macro.li('Name', metadata['report_parameters']['name']) }}
+      {{ macro.uuid(metadata['report_id']) }}
       {{ macro.li('Organization', metadata['provider']) }}
       {{ macro.li('Status', metadata['status']) }}
 </ul>

--- a/sfa_dash/templates/data/metadata/site_metadata.html
+++ b/sfa_dash/templates/data/metadata/site_metadata.html
@@ -4,6 +4,7 @@
 {% block metadata %}
 <ul class="data-metadata-fields col-md-6 col-xs-12">
   {{ macro.li('Name', name) }}
+  {{ macro.uuid(site_id) }}
   {{ macro.li('Latitude', latitude | string,  '&deg;N') }}
   {{ macro.li('Longitude', longitude | string,  '&deg;E') }}
   {{ macro.li('Timezone', timezone) }}

--- a/sfa_dash/templates/head.html
+++ b/sfa_dash/templates/head.html
@@ -50,6 +50,7 @@ Solar Forecast Arbiter Dashboard
 {% endif %}
 
 {# internal script inclusions #}
+<script src="/static/js/utils.js"></script>
 <script src="/static/js/table-search.js"></script>
 <script src="/static/js/table-checkall.js"></script>
 


### PR DESCRIPTION
closes #358 
Adds a "Copy UUID" button to the metadata section for observations, forecasts, probabilistic forecasts, aggregates and reports. Report copy uuid button exists in the metadata popups on the reports listing page. Button appears as follows:
![Screenshot from 2020-11-12 11-08-21](https://user-images.githubusercontent.com/21206164/98978691-9584a980-24d7-11eb-833a-ee5fa8fa4d9e.png)

Also allows users to click away from report metadata pop ups to close them instead of having to use the **close** button.