### PR TITLE
Move upload form to obs/fx page

### DIFF
--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -1,5 +1,7 @@
 import json
 from json.decoder import JSONDecodeError
+from requests.exceptions import HTTPError
+
 
 from flask import (Blueprint, render_template, request,
                    abort, redirect, url_for, flash)
@@ -198,6 +200,11 @@ class UploadForm(BaseView):
                                                     json=False)
                     except DataRequestException as e:
                         errors = e.errors
+                    except HTTPError as e:
+                        errors = {
+                            'Upload Failure': [
+                                'An error ocurred while uploading data.'],
+                        }
             elif posted_file.mimetype == 'application/json':
                 try:
                     posted_data = json.load(posted_file)
@@ -210,6 +217,11 @@ class UploadForm(BaseView):
                         self.api_handle.post_values(uuid, posted_data)
                     except DataRequestException as e:
                         errors = e.errors
+                    except HTTPError as e:
+                        errors = {
+                            'Upload Failure': [
+                                'An error ocurred while uploading data.'],
+                        }
             else:
                 errors = {
                     'mime-type': [

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -152,6 +152,9 @@ class CreateForm(BaseView):
 
 
 class UploadForm(BaseView):
+    # Manually override get method of parent to return 405
+    methods = ['POST']
+
     def __init__(self, data_type):
         self.data_type = data_type
         if data_type == 'observation':

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -155,39 +155,13 @@ class UploadForm(BaseView):
     def __init__(self, data_type):
         self.data_type = data_type
         if data_type == 'observation':
-            self.template = 'forms/observation_upload_form.html'
-            self.metadata_template = 'data/metadata/observation_metadata.html'
             self.api_handle = observations
         elif data_type == 'forecast':
-            self.template = 'forms/forecast_upload_form.html'
-            self.metadata_template = 'data/metadata/forecast_metadata.html'
             self.api_handle = forecasts
         elif data_type == 'cdf_forecast':
-            self.template = 'forms/cdf_forecast_upload_form.html'
-            self.metadata_template = 'data/metadata/cdf_forecast_metadata.html'
             self.api_handle = cdf_forecasts
         else:
             raise ValueError(f'No upload form defined for {data_type}')
-
-    def set_template_args(self):
-        self.template_args = {}
-        self.template_args['metadata_block'] = render_template(
-            self.metadata_template,
-            **self.metadata)
-        self.template_args['metadata'] = self.safe_metadata()
-
-    def get(self, uuid, **kwargs):
-        try:
-            self.metadata = self.api_handle.get_metadata(uuid)
-            self.set_site_or_aggregate_metadata()
-            self.metadata['site_link'] = self.generate_site_link(
-                self.metadata)
-        except DataRequestException as e:
-            return render_template(self.template, errors=e.errors)
-        else:
-            self.set_template_args()
-        return render_template(self.template, uuid=uuid, **self.template_args,
-                               **kwargs)
 
     def post(self, uuid):
         errors = {}
@@ -239,10 +213,9 @@ class UploadForm(BaseView):
                         f'Unsupported file type {posted_file.mimetype}.']
                 }
         if errors:
-            return self.get(uuid=uuid, errors=errors)
-        else:
-            return redirect(url_for(f'data_dashboard.{self.data_type}_view',
-                                    uuid=uuid))
+            self.flash_api_errors(errors)
+        return redirect(url_for(f'data_dashboard.{self.data_type}_view',
+                                uuid=uuid))
 
 
 class CloneForm(CreateForm):

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -196,6 +196,8 @@ class SingleObjectView(DataDashView):
         self.template_args['period_start_time'] = start.strftime('%H:%M')
         self.template_args['period_end_date'] = end.strftime('%Y-%m-%d')
         self.template_args['period_end_time'] = end.strftime('%H:%M')
+
+        self.template_args['data_type'] = self.data_type
         self.template_args.update(kwargs)
 
     def get(self, uuid, **kwargs):

--- a/sfa_dash/conftest.py
+++ b/sfa_dash/conftest.py
@@ -221,7 +221,6 @@ def site_id_route(request):
 
 observation_id_route_list = [
     '/observations/{observation_id}',
-    '/observations/{observation_id}/upload',
     '/observations/{observation_id}/delete',
 ]
 
@@ -235,7 +234,6 @@ def observation_id_route(request):
 
 forecast_id_route_list = [
     '/forecasts/single/{forecast_id}',
-    '/forecasts/single/{forecast_id}/upload',
     '/forecasts/single/{forecast_id}/delete',
 ]
 
@@ -261,7 +259,6 @@ def cdf_forecast_id_route(request):
 
 
 cdf_forecast_single_id_routes_list = [
-    '/forecasts/cdf/single/{forecast_id}/upload',
     '/forecasts/cdf/single/{forecast_id}',
 ]
 

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -698,3 +698,5 @@ div.report-header{
 a#ref-clear{
   color: #007bff;
 }
+.upload_block{
+}

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -698,5 +698,3 @@ div.report-header{
 a#ref-clear{
   color: #007bff;
 }
-.upload_block{
-}

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -3,8 +3,10 @@
 
 {% block content %}
 
-{% if upload_link is defined and is_allowed('write_values') %}
-<a role="button" class="btn btn-primary btn-sm" href="{{upload_link}}">Upload data</a>
+{% if is_allowed('write_values') %}
+{# if write_values is allowed, this button will control the display of the
+   upload form included below #}
+<a role="button" class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#upload-block">Upload data</a>
 {% endif %}
 
 {% if update_link is defined and is_allowed('update') %}
@@ -12,6 +14,18 @@
 {% endif %}
 {% if delete_link is defined and is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
+{% endif %}
+
+{% if is_allowed('write_values') %}
+<div id="upload-block" class="collapse border mb-3">
+    {% if data_type == 'observation' %}
+    {% include "forms/observation_upload_form.html" %}
+    {% elif data_type == 'forecast' %}
+    {% include "forms/forecast_upload_form.html" %}
+    {% elif data_type == 'cdf_forecast' %}
+    {% include "forms/cdf_forecast_upload_form.html" %}
+    {% endif %}
+</div>
 {% endif %}
 
 {% if plot is not none %}

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -3,12 +3,6 @@
 
 {% block content %}
 
-{% if is_allowed('write_values') %}
-{# if write_values is allowed, this button will control the display of the
-   upload form included below #}
-<a role="button" class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#upload-block">Upload data</a>
-{% endif %}
-
 {% if update_link is defined and is_allowed('update') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{update_link}}">Update Metadata</a>
 {% endif %}
@@ -16,17 +10,6 @@
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}
 
-{% if is_allowed('write_values') %}
-<div id="upload-block" class="collapse border mb-3">
-    {% if data_type == 'observation' %}
-    {% include "forms/observation_upload_form.html" %}
-    {% elif data_type == 'forecast' %}
-    {% include "forms/forecast_upload_form.html" %}
-    {% elif data_type == 'cdf_forecast' %}
-    {% include "forms/cdf_forecast_upload_form.html" %}
-    {% endif %}
-</div>
-{% endif %}
 
 {% if plot is not none %}
 <div class="row data-plots-wrapper">
@@ -39,4 +22,18 @@
 {% include "data/time_widgets.html" %}
 </div>
 {% endif %}
+{% if is_allowed('write_values') %}
+<a role="button" class="collapser-button collapsed" data-toggle="collapse" data-target="#upload-block">Upload data</a>
+<hr/>
+<div id="upload-block" class="collapse border mb-3">
+    {% if data_type == 'observation' %}
+    {% include "forms/observation_upload_form.html" %}
+    {% elif data_type == 'forecast' %}
+    {% include "forms/forecast_upload_form.html" %}
+    {% elif data_type == 'cdf_forecast' %}
+    {% include "forms/cdf_forecast_upload_form.html" %}
+    {% endif %}
+</div>
+{% endif %}
+
 {% endblock %}

--- a/sfa_dash/templates/data/metadata/observation_metadata.html
+++ b/sfa_dash/templates/data/metadata/observation_metadata.html
@@ -3,3 +3,6 @@
 {{ macro.li('Uncertainty', uncertainty, unit='&percnt;' )}}
 {% endblock %}
 {% set data_type = 'Observation' %}
+{% block upload_block %}
+{% include "forms/observation_upload_form.html" %}
+{% endblock %}

--- a/sfa_dash/templates/forms/base/upload_block.html
+++ b/sfa_dash/templates/forms/base/upload_block.html
@@ -1,11 +1,24 @@
 {% import "forms/form_macros.jinja" as form %}
-{% extends "dash/data.html" %}
-{% block extra_scripts %}
-<script src="/static/js/form-validation.js"></script>
-{% endblock %}
-{% block content %}
-{% if form_title %}<h3>{{ form_title }}</h3> {% endif %}
+
+{# Determine where to find the uuid of the object to upload. This is only valid
+   for observations, forecasts and cdf forecasts #}
 {% if metadata is defined %}
+  {% if 'site_id' in metadata %}
+    {% if 'observation_id' in metadata %}
+      {% set uuid = metadata['observation_id'] %}
+    {% elif 'forecast_id' in metadata %}
+      {% set uuid = metadata['forecast_id'] %}
+    {% endif %}
+  {% elif 'aggregate_id' in metadata %}
+    {% if 'forecast_id' in metadata %}
+      {% set uuid = 'forecast_id' %}
+    {% endif %}
+  {% endif %}
+{% endif %}
+{% if uuid is defined %}
+<script src="/static/js/form-validation.js"></script>
+{% if form_title %}<h3>{{ form_title }}</h3> {% endif %}
+
 <form action="{{ url_for('forms.upload_' + data_type + '_data', uuid=uuid) }}" method="post"  id="{{ data_type }}-upload-form" enctype='multipart/form-data'>
   <div class="form-group">
     {% block fields %}
@@ -24,4 +37,3 @@
   <button type="submit" form="{{ data_type }}-upload-form" value="Submit" class="btn btn-primary">Upload</button>
 </div>
 {% endif %}
-{% endblock %}

--- a/sfa_dash/templates/forms/cdf_forecast_upload_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_upload_form.html
@@ -1,4 +1,4 @@
-{% extends "forms/base/upload_form.html" %}
+{% extends "forms/base/upload_block.html" %}
 {% set page_title = 'Upload Forecast data' %}
 {% set data_type = "cdf_forecast" %}
 {% block fields %}

--- a/sfa_dash/templates/forms/forecast_upload_form.html
+++ b/sfa_dash/templates/forms/forecast_upload_form.html
@@ -1,4 +1,4 @@
-{% extends "forms/base/upload_form.html" %}
+{% extends "forms/base/upload_block.html" %}
 {% set page_title = 'Upload Forecast data' %}
 {% set data_type = 'forecast' %}
 {% block fields %}

--- a/sfa_dash/templates/forms/observation_upload_form.html
+++ b/sfa_dash/templates/forms/observation_upload_form.html
@@ -1,4 +1,4 @@
-{% extends "forms/base/upload_form.html" %}
+{% extends "forms/base/upload_block.html" %}
 {% set page_title = 'Upload Observation data' %}
 {% set data_type = 'observation' %}
 {% block fields %}

--- a/sfa_dash/tests/views/test_upload_405.py
+++ b/sfa_dash/tests/views/test_upload_405.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+from sfa_dash.conftest import BASE_URL
+
+
+@pytest.fixture
+def upload_routes(forecast_id, observation_id, cdf_forecast_id):
+    return [
+        f'/forecasts/single/{forecast_id}/upload',
+        f'/observations/{observation_id}/upload',
+        f'/forecasts/cdf/single/{cdf_forecast_id}/upload']
+
+
+@pytest.fixture(params=[0,1,2])
+def single_upload_route(request, upload_routes):
+    return upload_routes[request.param]
+
+
+def assert_upload_get_not_allowed(client, single_upload_routes):
+    resp = client.get(single_upload_routes,
+                      base_url=BASE_URL)
+    assert resp.status_code == 405


### PR DESCRIPTION
closes #196 
Makes the **Upload Data** button control the collapse of the upload data form. I've left the button just below the metadata section, and when clicked the upload form expands below. Screenshots below.

Expanded:
![expanded](https://user-images.githubusercontent.com/21206164/98992946-05e8f600-24eb-11eb-98a5-219aff052dce.png)

After errors:
![errors](https://user-images.githubusercontent.com/21206164/98992977-100af480-24eb-11eb-83a7-7021480773b1.png)
