### PR TITLE
redirect to location view after deletion

### DIFF
--- a/sfa_dash/blueprints/delete.py
+++ b/sfa_dash/blueprints/delete.py
@@ -68,7 +68,25 @@ class DeleteConfirmation(DataDashView):
             # the confirmation page, redirect to confirm.
             return redirect(confirmation_url)
         try:
+            self.metadata = self.api_handle.get_metadata(uuid)
+        except DataRequestException:
+            redirect_url = url_for(f'data_dashboard.{self.data_type}s')
+        else:
+            if self.metadata.get('site_id') is not None:
+                if self.data_type == 'site':
+                    redirect_url = url_for('data_dashboard.sites')
+                else:
+                    redirect_url = url_for(f'data_dashboard.{self.data_type}s',
+                                           site_id=self.metadata['site_id'])
+            else:
+                if self.data_type == 'aggregate':
+                    redirect_url = url_for('data_dashboard.aggregates')
+                else:
+                    redirect_url = url_for(
+                        f'data_dashboard.{self.data_type}s',
+                        aggregate_id=self.metadata['aggregate_id'])
+        try:
             self.api_handle.delete(uuid)
         except DataRequestException as e:
             return self.get(uuid, errors=e.errors)
-        return redirect(url_for(f'data_dashboard.{self.data_type}s'))
+        return redirect(redirect_url)

--- a/sfa_dash/blueprints/delete.py
+++ b/sfa_dash/blueprints/delete.py
@@ -78,13 +78,15 @@ class DeleteConfirmation(DataDashView):
                 else:
                     redirect_url = url_for(f'data_dashboard.{self.data_type}s',
                                            site_id=self.metadata['site_id'])
-            else:
+            elif self.metadata.get('aggregate_id') is not None:
                 if self.data_type == 'aggregate':
                     redirect_url = url_for('data_dashboard.aggregates')
                 else:
                     redirect_url = url_for(
                         f'data_dashboard.{self.data_type}s',
                         aggregate_id=self.metadata['aggregate_id'])
+            else:
+                redirect_url = url_for(f'data_dashboard.{self.data_type}s')
         try:
             self.api_handle.delete(uuid)
         except DataRequestException as e:


### PR DESCRIPTION
Closes #103 
When deleting an observation, forecast or probabilistic forecast, users will now be redirected to the associated site/aggregate's listing for that type. 