### PR TITLE
encode payload strings as utf-8

### DIFF
--- a/sfa_dash/api_interface/__init__.py
+++ b/sfa_dash/api_interface/__init__.py
@@ -75,8 +75,6 @@ def post_request(path, payload, json=True):
     if json:
         kwargs = {'json': payload}
     else:
-        if isinstance(payload, str):
-            payload = payload.encode('utf-8')
         kwargs = {'headers': {'Content-type': 'text/csv'},
                   'data': payload}
     return handle_response(oauth_request_session.post(

--- a/sfa_dash/api_interface/__init__.py
+++ b/sfa_dash/api_interface/__init__.py
@@ -75,6 +75,8 @@ def post_request(path, payload, json=True):
     if json:
         kwargs = {'json': payload}
     else:
+        if isinstance(payload, str):
+            payload = payload.encode('utf-8')
         kwargs = {'headers': {'Content-type': 'text/csv'},
                   'data': payload}
     return handle_response(oauth_request_session.post(

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -196,11 +196,11 @@ class UploadForm(BaseView):
                     }
                 else:
                     try:
-                        self.api_handle.post_values(uuid, decoded_data,
-                                                    json=False)
+                        self.api_handle.post_values(
+                            uuid, decoded_data.encode('utf-8'), json=False)
                     except DataRequestException as e:
                         errors = e.errors
-                    except HTTPError as e:
+                    except HTTPError:
                         errors = {
                             'Upload Failure': [
                                 'An error ocurred while uploading data.'],
@@ -217,7 +217,7 @@ class UploadForm(BaseView):
                         self.api_handle.post_values(uuid, posted_data)
                     except DataRequestException as e:
                         errors = e.errors
-                    except HTTPError as e:
+                    except HTTPError:
                         errors = {
                             'Upload Failure': [
                                 'An error ocurred while uploading data.'],


### PR DESCRIPTION
versus allowing requests to use latin-1 later in the pipeline

closes #389 