### PR TITLE
User failure

### DIFF
--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -11,7 +11,8 @@ def get_metadata(user_id):
     except HTTPError as e:
         if e.response.status_code == 500:
             raise DataRequestException(500, {
-                "errors": "Failed to load user info please try again."
+                "errors": ["Failed to load user info, please wait a minute "
+                           "and try again."]
             })
     return req
 
@@ -22,7 +23,8 @@ def list_metadata():
     except HTTPError as e:
         if e.response.status_code == 500:
             raise DataRequestException(500, {
-                "errors": "Failed to load user list, please try again."
+                "errors": ["Failed to load user list, please wait a minute "
+                           "and try again."]
             })
     return req
 
@@ -48,7 +50,8 @@ def get_metadata_by_email(email):
     except HTTPError as e:
         if e.response.status_code == 500:
             raise DataRequestException(500, {
-                "errors": "Failed to retrieve user by email, please try again."
+                "errors": ["Failed to retrieve user by email, please wait a "
+                           "minute and try again."]
             })
     return req
 
@@ -60,7 +63,8 @@ def add_role_by_email(email, role_id):
     except HTTPError as e:
         if e.response.status_code == 500:
             raise DataRequestException(500, {
-                "errors": "Failed to grant role by email, please try again."
+                "errors": ["Failed to grant role by email, please wait a "
+                           "minute and try again."]
             })
     return req
 
@@ -71,7 +75,8 @@ def remove_role_by_email(email, role_id):
     except HTTPError as e:
         if e.response.status_code == 500:
             raise DataRequestException(500, {
-                "errors": "Failed to remove role by email, please try again."
+                "errors": ["Failed to remove role by email, please wait a "
+                           "minute and try again."]
             })
     return req
 
@@ -82,7 +87,8 @@ def get_email(user_id):
     except HTTPError as e:
         if e.response.status_code == 500:
             raise DataRequestException(500, {
-                "errors": "Failed to look up user email, please try again."
+                "errors": ["Failed to look up user email, please wait a "
+                           "minute and try again."]
             })
     return req
 

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -1,13 +1,29 @@
+from requests.exceptions import HTTPError
+
+
 from sfa_dash.api_interface import get_request, post_request, delete_request
+from sfa_dash.errors import DataRequestException
 
 
 def get_metadata(user_id):
-    req = get_request(f'/users/{user_id}')
+    try:
+        req = get_request(f'/users/{user_id}')
+    except HTTPError as e:
+        if e.response.status_code == 500:
+            raise DataRequestException(500, {
+                "errors": "Failed to load user info please try again."
+            })
     return req
 
 
 def list_metadata():
-    req = get_request('/users/')
+    try:
+        req = get_request('/users/')
+    except HTTPError as e:
+        if e.response.status_code == 500:
+            raise DataRequestException(500, {
+                "errors": "Failed to load user list, please try again."
+            })
     return req
 
 
@@ -27,23 +43,47 @@ def remove_role(user_id, role_id):
 
 
 def get_metadata_by_email(email):
-    req = get_request(f'/users-by-email/{email}')
+    try:
+        req = get_request(f'/users-by-email/{email}')
+    except HTTPError as e:
+        if e.response.status_code == 500:
+            raise DataRequestException(500, {
+                "errors": "Failed to retrieve user by email, please try again."
+            })
     return req
 
 
 def add_role_by_email(email, role_id):
-    req = post_request(f'/users-by-email/{email}/roles/{role_id}',
-                       payload=None)
+    try:
+        req = post_request(f'/users-by-email/{email}/roles/{role_id}',
+                           payload=None)
+    except HTTPError as e:
+        if e.response.status_code == 500:
+            raise DataRequestException(500, {
+                "errors": "Failed to grant role by email, please try again."
+            })
     return req
 
 
 def remove_role_by_email(email, role_id):
-    req = delete_request(f'/users-by-email/{email}/roles/{role_id}')
+    try:
+        req = delete_request(f'/users-by-email/{email}/roles/{role_id}')
+    except HTTPError as e:
+        if e.response.status_code == 500:
+            raise DataRequestException(500, {
+                "errors": "Failed to remove role by email, please try again."
+            })
     return req
 
 
 def get_email(user_id):
-    req = get_request(f'/users/{user_id}/email')
+    try:
+        req = get_request(f'/users/{user_id}/email')
+    except HTTPError as e:
+        if e.response.status_code == 500:
+            raise DataRequestException(500, {
+                "errors": "Failed to look up user email, please try again."
+            })
     return req
 
 

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -1,5 +1,7 @@
 from flask import (Blueprint, render_template, request,
                    url_for, redirect, session, flash)
+
+
 from sfa_dash.api_interface import (
     sites, observations, forecasts,
     cdf_forecast_groups, roles, users,
@@ -84,9 +86,11 @@ class AdminView(BaseView):
 # Users Views
 class UserListing(AdminView):
     def get(self):
-        users_list = users.list_metadata()
-        if 'errors' in users_list:
-            users_list = None
+        try:
+            users_list = users.list_metadata()
+        except DataRequestException as e:
+            self.flash_api_errors(e.errors)
+            users_list = []
         self.set_template_args()
         return render_template('forms/admin/users.html',
                                table_data=users_list,
@@ -271,7 +275,11 @@ class RoleView(AdminView):
                                if k in permission_map}
 
         # Create a dict of users indexed on user uuid
-        user_list = users.list_metadata()
+        try:
+            user_list = users.list_metadata()
+        except DataRequestException as e:
+            self.flash_api_errors(e.errors)
+            user_list = []
         user_map = {user['user_id']: user
                     for user in user_list}
 

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -352,9 +352,12 @@ class RoleGrant(AdminView):
             url_for('admin.role_view', uuid=uuid))
         try:
             users.add_role_by_email(user_email, uuid)
-        except DataRequestException:
-            # flash a message that grant failed
-            flash('Failed to grant role.', 'error')
+        except DataRequestException as e:
+            if e.status_code == 500:
+                self.flash_api_errors(e.errors)
+            else:
+                # flash a message that grant failed
+                flash('Failed to grant role.', 'error')
             try:
                 role = roles.get_metadata(uuid)
             except DataRequestException as e:


### PR DESCRIPTION
Adds HTTP status code 500 error handling to dashboard pages that utilize the auth0 management api through the SFA API. There have been a couple of redis outages that cause the api to 500.(https://github.com/SolarArbiter/solarforecastarbiter-api/issues/310) These outages have lasted ~1 minute, so this PR displays an error message to wait a minute and try again. Initially I thought about handling these on the api, but it seems like something we'd like to be alerted to through sentry, but not fail on the dashboard as well. 