### PR TITLE
Handle Download Data Error

### DIFF
--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -385,4 +385,10 @@ class AggregateView(BaseView):
     def post(self, uuid):
         """Download endpoint.
         """
-        return download_timeseries(self, uuid)
+        try:
+            data_response = download_timeseries(self, uuid)
+        except DataRequestException as e:
+            self.flash_api_errors(e)
+            return self.get(uuid)
+        else:
+            return data_response

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -5,6 +5,7 @@ from functools import partial
 from flask import url_for, render_template, request, flash, current_app
 from flask.views import MethodView
 import pandas as pd
+from sentry_sdk import capture_exception
 
 from sfa_dash.api_interface import sites, aggregates
 from sfa_dash.blueprints.util import timeseries_adapter
@@ -163,6 +164,10 @@ class BaseView(MethodView):
         """
         start_dt = pd.Timestamp(form_data['start'], tz='utc')
         end_dt = pd.Timestamp(form_data['end'], tz='utc')
+        if (pd.isnull(start_dt) or pd.isnull(end_dt)):
+          err = ValueError("Invalid datetimes received from download form")
+          capture_exception(err)
+          raise err
         params = {
             'start': start_dt.isoformat(),
             'end': end_dt.isoformat(),

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -215,7 +215,13 @@ class SingleObjectView(DataDashView):
     def post(self, uuid):
         """Data download endpoint.
         """
-        return download_timeseries(self, uuid)
+        try:
+            data_response = download_timeseries(self, uuid)
+        except DataRequestException as e:
+            self.flash_api_errors(e)
+            return self.get(uuid)
+        else:
+            return data_response
 
 
 class SingleCDFForecastGroupView(SingleObjectView):

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -812,3 +812,8 @@ div.report-header {
 a#ref-clear {
   color: #007bff;
 }
+
+.iebanner {
+  padding: 1em;
+  text-align: center;
+}

--- a/sfa_dash/templates/base.html
+++ b/sfa_dash/templates/base.html
@@ -34,4 +34,15 @@
       </div>
     </footer>
   </body>
+  <script>
+    if (window.navigator.userAgent.match(/MSIE|Trident/) !== null) {
+      var main = document.getElementsByTagName("main")[0];
+      var firstContainer = main.getElementsByClassName("container")[0];
+      var ieBanner = document.createElement("div");
+      ieBanner.className = "iebanner alert-warning";
+      ieBanner.innerText = 'Internet Explorer detected, some features may not \
+                            work. We recommend using Firefox, Chrome or Edge.'
+      main.insertBefore(ieBanner, firstContainer);
+    }
+  </script>
 </html>

--- a/sfa_dash/templates/data/time_widgets.html
+++ b/sfa_dash/templates/data/time_widgets.html
@@ -28,8 +28,8 @@ or download data. A maximum of one year of data may be downloaded.{% endif %}
   <form action="" method="post" id="download-form" onsubmit="ParseStartEnd()">
   <button type="submit" id="download-submit" form="download-form" value="Submit" class="btn btn-primary mt-2">Download data</button>
   <label for="format">Format: </label>
-  <input type="radio" name="format" value="text/csv" checked>CSV</input>
-  <input type="radio" name="format" value="application/json">JSON</input>
+  <input type="radio" name="format" value="text/csv" checked>CSV
+  <input type="radio" name="format" value="application/json">JSON
   &lpar;<a href="https://solarforecastarbiter.org/datamodel/#downloads" target="_blank">format examples</a>&rpar;
   <input type="text" class="start" name="start" hidden>
   <input type="text" class="end" name="end" hidden>

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -26,7 +26,7 @@
 	 <div class="form-element">
        <label for="start">Start (UTC):</label><br/>
        <div class="input-wrapper">
-         <input type="text" name="period-start" class="form-control" placeholder="YYYY-MM-DDTHH:MMZ" required {% if form_data %}value="{{form_data['report_parameters']['period-start']}}"{% endif %}></input>
+         <input type="text" name="period-start" class="form-control" placeholder="YYYY-MM-DDTHH:MMZ" required {% if form_data %}value="{{form_data['report_parameters']['period-start']}}"{% endif %}>
        </div>
        {{ form.help_button('period-start') }}
        <span class="period-start-help-text form-text text-muted help-text collapse" aria-hidden>
@@ -36,7 +36,7 @@
      <div class="form-element">
        <label for="end">End (UTC)</label><br/>
        <div class="input-wrapper">
-         <input type="text" name="period-end" class="form-control" placeholder="YYYY-MM-DDTHH:MMZ" required {% if form_data %}value="{{form_data['report_parameters']['period-end']}}"{% endif %}></input>
+         <input type="text" name="period-end" class="form-control" placeholder="YYYY-MM-DDTHH:MMZ" required {% if form_data %}value="{{form_data['report_parameters']['period-end']}}"{% endif %}>
        </div>
        {{ form.help_button('period-end') }}
        <span class="period-end-help-text form-text text-muted help-text collapse" aria-hidden>


### PR DESCRIPTION
https://sentry.io/organizations/solararbiter-rx/issues/2138278848/?project=1472478&query=url%3A%22https%3A%2F%2Fdashboard.solarforecastarbiter.org%2Fobservations%2F063d42da-99fe-11e9-8674-0a580a8200c9%22

Handles two problems from the above Sentry error:
1. If the download failed, `set_template_args` wasn't called so an exception was raised trying to access the `template_args` attribute. Instead of handling this exception inside of the `download_timeseries` helper the View classes that utilize it handle the exception, flash the error and return their get method.
2. Raise an error when a NaT type makes it into the form. In the sentry error above, query parameters of `start=NaT&end=NaT` were passed. This should be handled by the `parse_start_end_from_querystring` method of `BaseView`, which should populate the start and end inputs on the page with the most recent valid times.  It appears there may be a case where the javascript to setup the time parameters is not running properly on IE11. More investigation is needed there. For the time being, I've adjusted the `format_download_params` function to raise an error if a NaT value gets through, and send the exception to Sentry for more context, The use will then be presented with an "invalid datetime" error instead of the 500 with the offending query parameters removed.