### PR TITLE
Pin Werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ prometheus_flask_exporter
 sentry_sdk
 blinker
 jsonschema==3.0.1
+werkzeug==1.0.1


### PR DESCRIPTION
Workzeug 2.0.0 triggered https://sentry.io/organizations/solararbiter-rx/issues/2394111331/?project=1472478

The issue is that sessions and cookies are removed from werkzeug and moved to their own package now:
See: https://werkzeug.palletsprojects.com/en/2.0.x/changes/#version-2-0-0 and https://github.com/pallets/secure-cookie
These changes breaks how flask dance, our oauth workflow library, handles accessing tokens etc. Pinning Werkzeug fixes the issue for now.