### PR TITLE
Pin Werkzeug version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==1.0.2
+jinja2==2.10
 Flask-SeaSurf==0.2.2
 requests==2.21.0
 flask-dance

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ prometheus_flask_exporter
 sentry_sdk
 blinker
 jsonschema==3.0.1
+werkzeug==1.0.1


### PR DESCRIPTION
Workzeug 2.0.0 triggered https://sentry.io/organizations/solararbiter-rx/issues/2394111331/?project=1472478

Pins the werkzeug version to avoid these issues until we can address updating

