### PR TITLE
Make report header rules more specific

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -551,7 +551,10 @@ th.selection-column {
 
 /* add pseudo elements so possible anchors clear sticky header */
 @media (min-width: 768px){
-  #report-block [id]:before{
+  #report-block h1[id]:before,
+  #report-block h2[id]:before,
+  #report-block h3[id]:before,
+  #report-block h4[id]:before{
       display: block;
       content: " ";
       margin-top: -7rem;


### PR DESCRIPTION
closes #422 
The selector for introducing pseudo elements to report headers such that they clear the sticky site header was too generic and effecting plotly's ability to layout correctly. This updates those selectors to only hit the headers on the page, resulting in correct plotly height layouts.