### PR TITLE
Support Report Timezone

### DIFF
--- a/sfa_dash/form_utils/converters.py
+++ b/sfa_dash/form_utils/converters.py
@@ -622,6 +622,11 @@ class ReportConverter(FormConverter):
             cost_name = None
         for pair in report_params['object_pairs']:
             pair.update({'cost': cost_name})
+
+        tz = form_dict.get('timezone')
+        if tz == '':
+            tz = None
+        report_params['timezone'] = tz
         return report_dict
 
     @classmethod
@@ -644,6 +649,10 @@ class ReportConverter(FormConverter):
         # see sfa_dash/static/js/report-utilities.js fill_object_pairs function
         form_params['object_pairs'] = report_parameters['object_pairs']
         form_params.update(cls.parse_api_filters(report_parameters))
+        tz = report_parameters.get('timezone')
+        if tz is None:
+            tz = ""
+        form_params['timezone'] = tz
         return {'report_parameters': form_params}
 
 

--- a/sfa_dash/form_utils/tests/test_converter.py
+++ b/sfa_dash/form_utils/tests/test_converter.py
@@ -629,3 +629,49 @@ def test_report_converter_apply_crps_crpss(pair, expected_metrics):
     updated = converters.ReportConverter.apply_crps(params)
     assert updated['metrics'] == expected_metrics
 
+
+def test_report_converter_payload_to_formdata_timezone_default(report):
+    form_data = converters.ReportConverter.payload_to_formdata(report)
+    assert form_data['report_parameters']['timezone'] == ""
+
+
+def test_report_converter_payload_to_formdata_timezone_null(report):
+    the_report = deepcopy(report)
+    the_report['report_parameters']['timezone'] = None
+    form_data = converters.ReportConverter.payload_to_formdata(the_report)
+    assert form_data['report_parameters']['timezone'] == ""
+
+
+@pytest.mark.parametrize("tz,expected", [
+    ("", None),
+    ("America/Pheonix", "America/Pheonix")
+])
+def test_report_converter_formdata_to_payload(report, tz, expected):
+    form_data = ImmutableMultiDict([
+        ('name', 'NREL MIDC OASIS GHI Forecast Analysis'),
+        ('start', '2019-04-01T07:00Z'),
+        ('end', '2019-06-01T06:59Z'),
+        ('forecast-id-0', '11c20780-76ae-4b11-bef1-7a75bdc784e3'),
+        ('truth-id-0', '123e4567-e89b-12d3-a456-426655440000'),
+        ('truth-type-0', 'observation'),
+        ('reference-forecast-0', 'null'),
+        ('deadband-value-0', 'null'),
+        ('forecast-type-0', 'forecast'),
+        ('observation-aggregate-radio', 'observation'),
+        ('site-select', '123e4567-e89b-12d3-a456-426655440001'),
+        ('forecast-select', '11c20780-76ae-4b11-bef1-7a75bdc784e3'),
+        ('observation-select', '123e4567-e89b-12d3-a456-426655440000'),
+        ('deadband-select', 'null'),
+        ('deadband-value', ''),
+        ('metrics', 'mae'),
+        ('metrics', 'rmse'),
+        ('categories', 'total'),
+        ('categories', 'date'),
+        ('quality_flags', 'USER FLAGGED'),
+        ('quality_flags', 'STALE VALUES'),
+        ('forecast_fill_method', 'forward'),
+        ('_csrf_token', '8a0771df3643d252cbafe4838263dbf7097f4982'),
+        ('timezone', tz)]
+    )
+    payload = converters.ReportConverter.formdata_to_payload(form_data)
+    assert payload['report_parameters']['timezone'] == expected

--- a/sfa_dash/form_utils/tests/test_converter.py
+++ b/sfa_dash/form_utils/tests/test_converter.py
@@ -644,7 +644,7 @@ def test_report_converter_payload_to_formdata_timezone_null(report):
 
 @pytest.mark.parametrize("tz,expected", [
     ("", None),
-    ("America/Pheonix", "America/Pheonix")
+    ("America/Phoenix", "America/Phoenix")
 ])
 def test_report_converter_formdata_to_payload(report, tz, expected):
     form_data = ImmutableMultiDict([

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -832,7 +832,7 @@ input.datetime-field {
   display: inline;
 }
 .datetime-field.year {
-  width: 2.5em;
+  width: 3em;
 }
 .datetime-field {
   width: 1.5em;

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -844,7 +844,7 @@ span.time-fields {
   display: inline-block;
 }
 span.date-field-wrapper:not(:last-child)::after {
-  content: "/";
+  content: "-";
 }
 span.time-field-wrapper:first-child::after {
   content: ":";

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -622,4 +622,5 @@ $(document).ready(function() {
     report_utils.register_uncertainty_handler('#observation-select');
     report_utils.insert_cost_widget();
     report_utils.register_forecast_fill_method_validator('deterministic');
+    report_utils.register_timezone_handlers();
 });

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -1504,3 +1504,18 @@ report_utils.remove_pair = function(fxid, obsid, reffxid, dblabel, dbvalue){
         x => !report_utils.compare_object_pairs(pair_object, x)
     )
 }
+
+report_utils.register_timezone_handlers = function (){
+  let tzSelect = $('select[name=timezone]')
+  tzSelect.change(function (){
+      let timezone = this.value;
+      if (timezone == '') {
+          timezone = 'UTC';
+      }
+      $('.datetime-start-label').text('Start('+timezone+')');
+      $('.datetime-end-label').text('End ('+timezone+')');
+  });
+  if (tzSelect.val() != '') {
+      tzSelect.change();
+  }
+}

--- a/sfa_dash/static/js/report-form-utilities.js
+++ b/sfa_dash/static/js/report-form-utilities.js
@@ -1512,7 +1512,7 @@ report_utils.register_timezone_handlers = function (){
       if (timezone == '') {
           timezone = 'UTC';
       }
-      $('.datetime-start-label').text('Start('+timezone+')');
+      $('.datetime-start-label').text('Start ('+timezone+')');
       $('.datetime-end-label').text('End ('+timezone+')');
   });
   if (tzSelect.val() != '') {

--- a/sfa_dash/static/js/timerange-handling.js
+++ b/sfa_dash/static/js/timerange-handling.js
@@ -109,13 +109,17 @@ function getStartValue() {
     const minute= $('[name="start minute"]').val();
 
     if (year && month && day && hour && minute) {
+        let timezoneInput = $('select[name=timezone]').val();
+        let timezone = timezoneInput ? timezoneInput : "UTC";
+
         return luxon.DateTime.fromObject({
            year: year,
            month: month,
            day: day,
            hour: hour,
            minute: minute,
-           zone: "UTC"
+        },{
+           zone: timezone
         });
     } else {
         return null;
@@ -130,13 +134,17 @@ function getEndValue() {
     const minute = $('[name="end minute"]').val();
 
     if (year && month && day && hour && minute) {
+        let timezoneInput = $('select[name=timezone]').val();
+        let timezone = timezoneInput ? timezoneInput : "UTC";
+
         return luxon.DateTime.fromObject({
             year: year,
             month: month,
             day: day,
             hour: hour,
             minute: minute,
-            zone: "UTC"
+        },{
+            zone: timezone
         });
     } else {
         return null;
@@ -156,6 +164,7 @@ function initDatetimeValues() {
     let end = $("[name=end]").val();
     let startObject;
     let endObject;
+    let timezone = $('select[name=timezone]').val();
     if (start != "") {
         try {
           startObject = luxon.DateTime.fromISO(start, {zone: "UTC"});
@@ -171,6 +180,9 @@ function initDatetimeValues() {
         }
     }
     if (startObject) {
+        if (timezone) {
+            startObject = startObject.setZone(timezone);
+        }
         $('[name="start year"]').val(startObject.year);
         $('[name="start month"]').val(startObject.month);
         $('[name="start day"]').val(startObject.day);
@@ -178,6 +190,9 @@ function initDatetimeValues() {
         $('[name="start minute"]').val(startObject.minute);
     }
     if (endObject) {
+        if (timezone) {
+            endObject = endObject.setZone(timezone);
+        }
         $('[name="end year"]').val(endObject.year);
         $('[name="end month"]').val(endObject.month);
         $('[name="end day"]').val(endObject.day);

--- a/sfa_dash/templates/data/time_inputs.html
+++ b/sfa_dash/templates/data/time_inputs.html
@@ -4,7 +4,7 @@ Modified from Solar Performance Insight dashboard/src/components/jobs/parameters
 See LICENSES/SOLARPERFORMANCEINSIGHT_LICENSE
 -->
 <div class="datetime-field-container">
-  <label>Start (UTC):</label><br/>
+  <label class="datetime-start-label">Start (UTC)</label><br/>
   <div class="datetime-container">
     <span class="date-fields start">
       <span class="date-field-wrapper">
@@ -75,10 +75,10 @@ See LICENSES/SOLARPERFORMANCEINSIGHT_LICENSE
       </span>
     </span>
   </div>
-  
+
 </div>
 <div class="datetime-field-container">
-  <label>End (UTC):</label><br />
+  <label class="datetime-end-label">End (UTC)</label><br />
   <div class="datetime-container">
     <span class="date-fields end">
       <span class="date-field-wrapper">

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -24,6 +24,19 @@
          <input type="text" class="form-control  name-field" required="" name="name" {{ form.name_validation() }} value="{% if form_data %}{{form_data['report_parameters']['name']}}{% else %}{%endif%}"/>
        </div>
      </div>
+     <!--- TIMEZONE STUFF -->
+     <div class="form-element full-width">
+       <label>Timezone</label>
+       <div class="input-wrapper">
+         <select class="form-control timezone-field" name="timezone">
+           <option value="">Infer timezone from selections</option>
+           {% for option, option_label in timezone_options.items() %}
+           <option value="{{ option }}" {% if option == form_data.get(name)  %} selected="selected"{% endif %}>{{ option_label }}</option>
+           {% endfor %}
+         </select>
+       </div>
+     </div>
+     <!-- END TIMEZONE STUFF  -->
      <div class="form-element full-width">
        {% include "data/time_inputs.html" %}
        <input type="text" hidden required name="start" class="form-control"  required {% if form_data %}value="{{form_data['report_parameters']['period-start']}}"{% endif %}>

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -24,19 +24,17 @@
          <input type="text" class="form-control  name-field" required="" name="name" {{ form.name_validation() }} value="{% if form_data %}{{form_data['report_parameters']['name']}}{% else %}{%endif%}"/>
        </div>
      </div>
-     <!--- TIMEZONE STUFF -->
      <div class="form-element full-width">
        <label>Timezone</label>
        <div class="input-wrapper">
          <select class="form-control timezone-field" name="timezone">
            <option value="">Infer timezone from selections</option>
            {% for option, option_label in timezone_options.items() %}
-           <option value="{{ option }}" {% if option == form_data['report_parameters']['timezone']  %} selected="selected"{% endif %}>{{ option_label }}</option>
+           <option value="{{ option }}" {% if form_data and option == form_data['report_parameters']['timezone'] %} selected="selected"{% endif %}>{{ option_label }}</option>
            {% endfor %}
          </select>
        </div>
      </div>
-     <!-- END TIMEZONE STUFF  -->
      <div class="form-element full-width">
        {% include "data/time_inputs.html" %}
        <input type="text" hidden required name="start" class="form-control"  required {% if form_data %}value="{{form_data['report_parameters']['period-start']}}"{% endif %}>

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -31,7 +31,7 @@
          <select class="form-control timezone-field" name="timezone">
            <option value="">Infer timezone from selections</option>
            {% for option, option_label in timezone_options.items() %}
-           <option value="{{ option }}" {% if option == form_data.get(name)  %} selected="selected"{% endif %}>{{ option_label }}</option>
+           <option value="{{ option }}" {% if option == form_data['report_parameters']['timezone']  %} selected="selected"{% endif %}>{{ option_label }}</option>
            {% endfor %}
          </select>
        </div>

--- a/sfa_dash/templates/head.html
+++ b/sfa_dash/templates/head.html
@@ -46,8 +46,8 @@ Solar Forecast Arbiter Dashboard
 {% endif %}
 
 <script
-    src="https://cdn.jsdelivr.net/npm/luxon@1.26.0/build/global/luxon.min.js"
-    integrity="sha256-4sbTzmCCW9LGrIh5OsN8V5Pfdad1F1MwhLAOyXKnsE0="
+    src="https://cdn.jsdelivr.net/npm/luxon@2.0.1/build/global/luxon.min.js"
+    integrity="sha256-BdqBGuaawDzMtW2Wn9ISUuYKUY/A7d5NVcj6Ix3jwv8="
     crossorigin="anonymous">
 </script>
 


### PR DESCRIPTION
closes #423 
Adds the option for a user to supply a timezone for a report, with the default option being "Infer from selections. I've dropped it in right above the start/end inputs like so: 
![Screenshot from 2021-07-21 14-44-07](https://user-images.githubusercontent.com/21206164/126564206-866a0f3f-d419-4647-8038-c07c0cb713ed.png)
