### PR TITLE
Add buttons for cloning sites/obs/fx

### DIFF
--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -288,7 +288,7 @@ class CloneForm(CreateForm):
                     flash('Could not read site metadata. Cloning failed.',
                           'error')
                     return redirect(
-                        url_for(f'data_dashboard.{self.data_type}', uuid=uuid))
+                        url_for(f'data_dashboard.{self.data_type}_view', uuid=uuid))
         return render_template(self.template, **self.template_args)
 
 

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -175,6 +175,7 @@ class SingleObjectView(DataDashView):
             self.metadata_template,
             **self.metadata)
         self.template_args['metadata'] = self.safe_metadata()
+        self.template_args['uuid'] = self.metadata[self.id_key]
         self.template_args['upload_link'] = url_for(
             f'forms.upload_{self.data_type}_data',
             uuid=self.metadata[self.id_key])

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -6,10 +6,14 @@
 {% if update_link is defined and is_allowed('update') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{update_link}}">Update Metadata</a>
 {% endif %}
+
+{% if can_create(data_type+'s') and ('site' in metadata or 'aggregate' in metadata) %}
+<a role="button" class="btn btn-primary btn-sm" href="{{url_for('forms.clone_'+data_type, uuid=uuid)}}">Clone Metadata</a>
+{% endif %}
+
 {% if delete_link is defined and is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}
-
 
 {% if plot is not none %}
 <div class="row data-plots-wrapper">

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -7,7 +7,10 @@
 <a role="button" class="btn btn-primary btn-sm" href="{{update_link}}">Update Metadata</a>
 {% endif %}
 
-{% if can_create(data_type+'s') and ('site' in metadata or 'aggregate' in metadata) %}
+{% if data_type is defined
+   and can_create(data_type+'s')
+   and ('site' in metadata or 'aggregate' in metadata)
+%}
 <a role="button" class="btn btn-primary btn-sm" href="{{url_for('forms.clone_'+data_type, uuid=uuid)}}">Clone Metadata</a>
 {% endif %}
 

--- a/sfa_dash/templates/data/cdf_forecast.html
+++ b/sfa_dash/templates/data/cdf_forecast.html
@@ -3,6 +3,9 @@
 {% if update_link is defined and is_allowed('update') %}
   <a role="button" class="btn btn-primary btn-sm" href="{{ update_link }}">Update</a>
 {% endif %}
+{% if can_create('cdf_forecasts') and ('site' in metadata or 'aggregate' in metadata) %}
+<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.clone_cdf_forecast_group', uuid=metadata['forecast_id'] ) }}">Clone Metadata</a>
+{% endif %}
 {% if delete_link is defined and is_allowed('delete') %}
   <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -15,8 +15,8 @@
   <a rold="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.update_site', uuid=site_id) }}">Update Metadata</a>
   {% endif %}
   {% if can_create('sites') %}
-<a role="button" class="btn btn-primary btn-sm" href="{{url_for('forms.clone_site', uuid=site_id)}}">Clone Metadata</a>
-{% endif %}
+  <a role="button" class="btn btn-primary btn-sm" href="{{url_for('forms.clone_site', uuid=site_id)}}">Clone Metadata</a>
+  {% endif %}
   {% if is_allowed('delete') %}
   <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_site', uuid=site_id) }}">Delete this site</a>
   {% endif %}

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -14,6 +14,9 @@
   {% if is_allowed('update') %}
   <a rold="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.update_site', uuid=site_id) }}">Update Metadata</a>
   {% endif %}
+  {% if can_create('sites') %}
+<a role="button" class="btn btn-primary btn-sm" href="{{url_for('forms.clone_site', uuid=site_id)}}">Clone Metadata</a>
+{% endif %}
   {% if is_allowed('delete') %}
   <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_site', uuid=site_id) }}">Delete this site</a>
   {% endif %}


### PR DESCRIPTION
related to #432 
Took a second to flesh this out because it was mostly done. I've added clone buttons to sites, observations, forecasts and cdf forecasts. Cloning aggregates is complicated so that option is not implemented.

Just checks if the 'aggregate' or 'site' key is loaded into metadata for obs/fx before allowing cloning, so we can ensure that the user has access to that object. 

Just adds a button to the row of buttons below the metadata section on any given page.

![Screenshot from 2021-08-13 11-09-43](https://user-images.githubusercontent.com/21206164/129401523-9eb67abb-a929-458d-973c-6e1f27416f59.png)
