### PR TITLE
Allow for full quality flag filter specification on dashboard

### DIFF
--- a/sfa_dash/form_utils/converters.py
+++ b/sfa_dash/form_utils/converters.py
@@ -546,11 +546,14 @@ class ReportConverter(FormConverter):
         """
         filters = []
         quality_flags = form_data.getlist('quality_flags')
-        for flag in quality_flags:
+        discards = form_data.getlist('discard_before_resample')
+        resamples = form_data.getlist('resample_threshold_percentage')
+
+        for i in range(len(quality_flags)):
             filters.append({
-                'quality_flags': [flag],
-                'discard_before_resample': flag in DISCARD_BEFORE_RESAMPLE,
-                'resample_threshold_percentage': QFF.resample_threshold_percentage,  # noqa: E501
+                'quality_flags': quality_flags[i].split(','),
+                'discard_before_resample': discards[i],
+                'resample_threshold_percentage': float(resamples[i])
             })
         return filters
 
@@ -648,7 +651,7 @@ class ReportConverter(FormConverter):
         # Objects pairs are left in the api format for parsing in javascript
         # see sfa_dash/static/js/report-utilities.js fill_object_pairs function
         form_params['object_pairs'] = report_parameters['object_pairs']
-        form_params.update(cls.parse_api_filters(report_parameters))
+        form_params['filters'] = report_parameters['filters']
         tz = report_parameters.get('timezone')
         if tz is None:
             tz = ""

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -205,7 +205,7 @@ ul.data-metadata-fields {
 }
 
 /* Forms */
-div.pair-container {
+div.pair-container, ul.quality-filter-list, li.qf-filter-container {
   list-style: none;
   padding: 0.5em 1em;
   position: relative;
@@ -234,7 +234,8 @@ ul.pair-attribute-list {
 }
 
 a.object-pair-delete-button,
-a.error-band-delete-button {
+a.error-band-delete-button,
+a.qf-filter-delete-button {
   position: absolute;
   top: 5px;
   right: 20px;
@@ -864,4 +865,8 @@ input[type="number"].datetime-field {
 .datetime-field-container {
   display: inline-block;
   min-width: 49%;
+}
+
+#quality-flag-container {
+    padding: 1em;
 }

--- a/sfa_dash/static/js/report-form-handling.js
+++ b/sfa_dash/static/js/report-form-handling.js
@@ -621,6 +621,7 @@ $(document).ready(function() {
     report_utils.fill_existing_pairs();
     report_utils.register_uncertainty_handler('#observation-select');
     report_utils.insert_cost_widget();
+    report_utils.insert_quality_flag_widget();
     report_utils.register_forecast_fill_method_validator('deterministic');
     report_utils.register_timezone_handlers();
 });

--- a/sfa_dash/templates/forms/base/base_report_form.html
+++ b/sfa_dash/templates/forms/base/base_report_form.html
@@ -93,14 +93,20 @@
      {% endif %}
 
      {% block quality_flag_field %}
-     <div class="form-element full-width">
+      <div class="form-element full-width">
        <label>Quality Flag Filters</label><br>
        <p>Observation data flagged with any of the checked quality flags is excluded from analysis. The corresponding forecast data is also excluded.</p>
-       {% for flag, label in quality_flags.items() %}
-       <input type="checkbox" name="quality_flags" value="{{ flag }}" {% if form_data %}{% if flag in form_data['report_parameters']['quality_flags'] %}checked{% endif %}{%endif %}> {{ label }}<br/>
-       {% endfor %}
+       <ul class="quality-filter-list">
+         <li class="no-quality-filters-warning qf-filter-container">No quality filters applied</li>
+       </ul>
+       
+     <a role="button" id="cost-param-collapse" data-toggle="collapse" data-target="#quality-flag-container" class="collapser-button collapsed" aria-expanded="true">Add Quality flag filter</a>
+     <fieldset id="quality-flag-container" class="collapse">
+     </fieldset>
+      
      </div>
      {% endblock %}
+
      {% block forecast_fill_method_field %}
      <div class="form-element full-width">
        <label>Forecast Fill Method</label><br>

--- a/sfa_dash/templates/head.html
+++ b/sfa_dash/templates/head.html
@@ -72,7 +72,8 @@ Solar Forecast Arbiter Dashboard
       DETERMINISTIC_METRICS: JSON.parse('{{ deterministic_metrics | tojson }}'),
       ALL_METRICS: JSON.parse('{{ all_metrics | tojson }}'),
       TIMEZONES: JSON.parse('{{ timezone_options | tojson }}'),
-      METRICS_REQ_REF: JSON.parse('{{ REQ_REF_FX | tojson }}')
+      METRICS_REQ_REF: JSON.parse('{{ REQ_REF_FX | tojson }}'),
+      QUALITY_FLAGS: JSON.parse('{{ quality_flags | tojson }}'),
     }
 </script>
 {# inject the page_data json variable if provided by jinja #}


### PR DESCRIPTION
Adds quality flag interface to report forms on the dashboard.
![Screenshot from 2021-08-20 16-48-04](https://user-images.githubusercontent.com/21206164/130303342-7223e987-dffe-41b8-b569-e1ace51fc105.png)

- [ ] Styling needs a few tweaks for spacing/overlapping remove buttons.
- [ ] Needs to be setup for events and probabilistic reports.
