### PR TITLE
Link to forecast definitions from forecast forms

### DIFF
--- a/sfa_dash/templates/dash/data.html
+++ b/sfa_dash/templates/dash/data.html
@@ -39,6 +39,9 @@
 </h2>
 {% endif %}
 
+{% block subheading %}
+{% endblock %}
+
 {% include "sections/subnav.html" %}
 
 {% if metadata_block is defined %}

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -5,6 +5,11 @@
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}
+
+{% block subheading %}
+See <a href="https://solarforecastarbiter.org/definitions/">forecast definitions</a> for detailed explanation.
+{% endblock %}
+
 {% block fields %}
 <div class="form-element">
   {{ form.input('Name', 'text', 'name', 'Name for the Forecast',

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -7,7 +7,7 @@
 {% endif %}
 
 {% block subheading %}
-See <a href="https://solarforecastarbiter.org/definitions/">forecast definitions</a> for detailed explanation.
+See <a href="https://solarforecastarbiter.org/definitions/">forecast definitions</a> for detailed explanations of parameters.
 {% endblock %}
 
 {% block fields %}

--- a/sfa_dash/templates/forms/forecast_form.html
+++ b/sfa_dash/templates/forms/forecast_form.html
@@ -5,6 +5,11 @@
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}
+
+{% block subheading %}
+See <a href="https://solarforecastarbiter.org/definitions/">forecast definitions</a> for detailed explanation.
+{% endblock %}
+
 {% block fields %}
 <div class="form-element">
   {{ form.input('Name', 'text', 'name', 'Name for the Forecast',

--- a/sfa_dash/templates/forms/forecast_form.html
+++ b/sfa_dash/templates/forms/forecast_form.html
@@ -7,7 +7,7 @@
 {% endif %}
 
 {% block subheading %}
-See <a href="https://solarforecastarbiter.org/definitions/">forecast definitions</a> for detailed explanation.
+See <a href="https://solarforecastarbiter.org/definitions/">forecast definitions</a> for detailed explanations of parameters.
 {% endblock %}
 
 {% block fields %}


### PR DESCRIPTION
Adds a link to the forecast definition page on forecast form by introducing a `subheading` block right underneath the page title
![Screenshot from 2021-09-16 10-23-48](https://user-images.githubusercontent.com/21206164/133657337-e8edf30c-25a8-43e7-a562-b4c5f6f4f52c.png)
. 